### PR TITLE
Rework public interface

### DIFF
--- a/bzip2.rs
+++ b/bzip2.rs
@@ -8,7 +8,7 @@ use std::ffi::{c_char, CStr};
 use std::mem::zeroed;
 use std::ptr;
 
-use libbzip2_rs_sys::bzlib::{
+use libbzip2_rs_sys::{
     BZ2_bzRead, BZ2_bzReadClose, BZ2_bzReadGetUnused, BZ2_bzReadOpen, BZ2_bzWrite,
     BZ2_bzWriteClose64, BZ2_bzWriteOpen, BZ2_bzlibVersion,
 };

--- a/bzlib.rs
+++ b/bzlib.rs
@@ -865,7 +865,7 @@ unsafe fn handle_compress(strm: &mut bz_stream, s: &mut EState) -> bool {
     progress_in || progress_out
 }
 
-enum Action {
+pub(crate) enum Action {
     Run = 0,
     Flush = 1,
     Finish = 2,

--- a/c2rust-lib.rs
+++ b/c2rust-lib.rs
@@ -3,14 +3,17 @@
 #![allow(clippy::missing_safety_doc)] // FIXME remove once everything has safety docs
 #![allow(clippy::needless_range_loop)] // FIXME remove once all instances are fixed
 
+use core::ffi::c_int;
+
 extern crate libc;
-pub mod blocksort;
-pub mod bzlib;
-pub mod compress;
-pub mod crctable;
-pub mod decompress;
-pub mod huffman;
-pub mod randtable;
+
+mod blocksort;
+mod bzlib;
+mod compress;
+mod crctable;
+mod decompress;
+mod huffman;
+mod randtable;
 
 #[macro_export]
 macro_rules! assert_h {
@@ -20,3 +23,44 @@ macro_rules! assert_h {
         }
     }};
 }
+
+pub(crate) use bzlib::{Action, ReturnCode};
+
+pub const BZ_OK: c_int = ReturnCode::BZ_OK as c_int;
+pub const BZ_RUN_OK: c_int = ReturnCode::BZ_RUN_OK as c_int;
+pub const BZ_FLUSH_OK: c_int = ReturnCode::BZ_FLUSH_OK as c_int;
+pub const BZ_FINISH_OK: c_int = ReturnCode::BZ_FINISH_OK as c_int;
+pub const BZ_STREAM_END: c_int = ReturnCode::BZ_STREAM_END as c_int;
+pub const BZ_SEQUENCE_ERROR: c_int = ReturnCode::BZ_SEQUENCE_ERROR as c_int;
+pub const BZ_PARAM_ERROR: c_int = ReturnCode::BZ_PARAM_ERROR as c_int;
+pub const BZ_MEM_ERROR: c_int = ReturnCode::BZ_MEM_ERROR as c_int;
+pub const BZ_DATA_ERROR: c_int = ReturnCode::BZ_DATA_ERROR as c_int;
+pub const BZ_DATA_ERROR_MAGIC: c_int = ReturnCode::BZ_DATA_ERROR_MAGIC as c_int;
+pub const BZ_IO_ERROR: c_int = ReturnCode::BZ_IO_ERROR as c_int;
+pub const BZ_UNEXPECTED_EOF: c_int = ReturnCode::BZ_UNEXPECTED_EOF as c_int;
+pub const BZ_OUTBUFF_FULL: c_int = ReturnCode::BZ_OUTBUFF_FULL as c_int;
+pub const BZ_CONFIG_ERROR: c_int = ReturnCode::BZ_CONFIG_ERROR as c_int;
+
+pub const BZ_RUN: c_int = Action::Run as c_int;
+pub const BZ_FLUSH: c_int = Action::Flush as c_int;
+pub const BZ_FINISH: c_int = Action::Finish as c_int;
+
+// types
+pub use bzlib::bz_stream;
+
+// the low-level interface
+pub use bzlib::{BZ2_bzCompress, BZ2_bzCompressEnd, BZ2_bzCompressInit};
+pub use bzlib::{BZ2_bzDecompress, BZ2_bzDecompressEnd, BZ2_bzDecompressInit};
+
+// utility functions
+pub use bzlib::{BZ2_bzBuffToBuffCompress, BZ2_bzBuffToBuffDecompress};
+
+// the high-level interface
+pub use bzlib::{BZ2_bzRead, BZ2_bzReadClose, BZ2_bzReadGetUnused, BZ2_bzReadOpen};
+pub use bzlib::{BZ2_bzWrite, BZ2_bzWriteClose, BZ2_bzWriteClose64, BZ2_bzWriteOpen};
+
+// zlib compatibility functions
+pub use bzlib::{
+    BZ2_bzclose, BZ2_bzdopen, BZ2_bzerror, BZ2_bzflush, BZ2_bzlibVersion, BZ2_bzopen, BZ2_bzread,
+    BZ2_bzwrite,
+};

--- a/c2rust-lib.rs
+++ b/c2rust-lib.rs
@@ -3,6 +3,8 @@
 #![allow(clippy::missing_safety_doc)] // FIXME remove once everything has safety docs
 #![allow(clippy::needless_range_loop)] // FIXME remove once all instances are fixed
 
+//! A drop-in compatible rust implementation of bzip2
+
 use core::ffi::c_int;
 
 extern crate libc;

--- a/test-libbzip2-rs-sys/src/chunked.rs
+++ b/test-libbzip2-rs-sys/src/chunked.rs
@@ -1,7 +1,7 @@
 use crate::{compress_c, decompress_c, SAMPLE1_BZ2, SAMPLE1_REF};
 
 fn decompress_rs_chunked_input<'a>(dest: &'a mut [u8], source: &[u8]) -> Result<&'a mut [u8], i32> {
-    use libbzip2_rs_sys::bzlib::*;
+    use libbzip2_rs_sys::*;
 
     let mut dest_len = dest.len() as _;
 
@@ -70,7 +70,7 @@ fn decompress_chunked_input() {
 }
 
 fn compress_rs_chunked_input<'a>(dest: &'a mut [u8], source: &[u8]) -> Result<&'a mut [u8], i32> {
-    use libbzip2_rs_sys::bzlib::*;
+    use libbzip2_rs_sys::*;
 
     let mut dest_len = dest.len() as _;
 
@@ -155,7 +155,7 @@ fn decompress_rs_chunked_output<'a>(
     dest: &'a mut [u8],
     source: &[u8],
 ) -> Result<&'a mut [u8], i32> {
-    use libbzip2_rs_sys::bzlib::*;
+    use libbzip2_rs_sys::*;
 
     let mut dest_len = dest.len() as core::ffi::c_uint;
 
@@ -224,7 +224,7 @@ fn decompress_chunked_output() {
 }
 
 fn compress_rs_chunked_output<'a>(dest: &'a mut [u8], source: &[u8]) -> Result<&'a mut [u8], i32> {
-    use libbzip2_rs_sys::bzlib::*;
+    use libbzip2_rs_sys::*;
 
     let mut dest_len = dest.len() as core::ffi::c_uint;
 

--- a/test-libbzip2-rs-sys/src/lib.rs
+++ b/test-libbzip2-rs-sys/src/lib.rs
@@ -641,8 +641,6 @@ mod bzip2_testfiles {
 
 #[test]
 fn decompress_init_edge_cases() {
-    use bzip2_sys::{BZ_MEM_ERROR, BZ_OK, BZ_PARAM_ERROR};
-
     // valid input
     crate::assert_eq_rs_c!({
         let mut strm = MaybeUninit::zeroed();
@@ -700,8 +698,6 @@ fn decompress_init_edge_cases() {
 
 #[test]
 fn decompress_edge_cases() {
-    use bzip2_sys::{BZ_MEM_ERROR, BZ_OK, BZ_PARAM_ERROR, BZ_STREAM_END};
-
     // strm is NULL
     crate::assert_eq_rs_c!({
         assert_eq!(BZ_PARAM_ERROR, BZ2_bzDecompress(core::ptr::null_mut()));
@@ -785,8 +781,6 @@ fn decompress_edge_cases() {
 
 #[test]
 fn decompress_end_edge_cases() {
-    use bzip2_sys::{BZ_MEM_ERROR, BZ_OK, BZ_PARAM_ERROR};
-
     // strm is NULL
     crate::assert_eq_rs_c!({
         assert_eq!(BZ_PARAM_ERROR, BZ2_bzDecompressEnd(core::ptr::null_mut()));
@@ -826,8 +820,6 @@ fn decompress_end_edge_cases() {
 
 #[test]
 fn compress_init_edge_cases() {
-    use bzip2_sys::{BZ_MEM_ERROR, BZ_OK, BZ_PARAM_ERROR};
-
     let blockSize100k = 9;
     let verbosity = 0;
     let workFactor = 30;
@@ -942,11 +934,6 @@ fn compress_init_edge_cases() {
 
 #[test]
 fn compress_edge_cases() {
-    use bzip2_sys::{
-        BZ_FINISH, BZ_FINISH_OK, BZ_FLUSH, BZ_FLUSH_OK, BZ_MEM_ERROR, BZ_OK, BZ_PARAM_ERROR,
-        BZ_RUN, BZ_RUN_OK, BZ_SEQUENCE_ERROR, BZ_STREAM_END,
-    };
-
     let blockSize100k = 9;
     let verbosity = 0;
     let workFactor = 30;
@@ -1100,11 +1087,6 @@ fn compress_edge_cases() {
 
 #[test]
 fn compress_64_bit_arithmetic_edge_cases() {
-    use bzip2_sys::{
-        BZ_FINISH, BZ_FINISH_OK, BZ_FLUSH, BZ_FLUSH_OK, BZ_MEM_ERROR, BZ_OK, BZ_PARAM_ERROR,
-        BZ_RUN, BZ_RUN_OK, BZ_SEQUENCE_ERROR, BZ_STREAM_END,
-    };
-
     let mut output = [0u8; 64];
 
     let blockSize100k = 9;
@@ -1194,11 +1176,6 @@ fn compress_64_bit_arithmetic_edge_cases() {
 
 #[test]
 fn compress_action_edge_cases() {
-    use bzip2_sys::{
-        BZ_FINISH, BZ_FINISH_OK, BZ_FLUSH, BZ_FLUSH_OK, BZ_MEM_ERROR, BZ_OK, BZ_PARAM_ERROR,
-        BZ_RUN, BZ_RUN_OK, BZ_SEQUENCE_ERROR, BZ_STREAM_END,
-    };
-
     let mut output = [0u8; 64];
 
     let blockSize100k = 9;
@@ -1257,8 +1234,6 @@ fn compress_action_edge_cases() {
 
 #[test]
 fn compress_end_edge_cases() {
-    use bzip2_sys::{BZ_MEM_ERROR, BZ_OK, BZ_PARAM_ERROR};
-
     let blockSize100k = 9;
     let verbosity = 0;
     let workFactor = 30;
@@ -1357,7 +1332,7 @@ mod high_level_interface {
                 )
             };
 
-            if bzerror == bzip2_sys::BZ_OK || bzerror == bzip2_sys::BZ_STREAM_END {
+            if bzerror == BZ_OK || bzerror == BZ_STREAM_END {
                 output.extend(&buffer[..bytes_read as usize]);
             }
         }
@@ -1369,9 +1344,9 @@ mod high_level_interface {
 
         unsafe { libc::fclose(input_file) };
 
-        assert_eq!(after_read, bzip2_sys::BZ_STREAM_END);
+        assert_eq!(after_read, BZ_STREAM_END);
 
-        assert_eq!(bzerror, bzip2_sys::BZ_OK);
+        assert_eq!(bzerror, BZ_OK);
 
         assert_eq!(&expected[..expected_len as usize], output);
     }
@@ -1438,7 +1413,7 @@ mod high_level_interface {
 
         unsafe { libc::fclose(output_file) };
 
-        assert_eq!(bzerror, bzip2_sys::BZ_OK);
+        assert_eq!(bzerror, BZ_OK);
 
         let mut expected = vec![0u8; 256 * 1024];
         let mut expected_len = expected.len() as _;


### PR DESCRIPTION
nicely export (most of?) the required symbols from the crate root. 