### PR TITLE
Improve encapsulation of unsafe code

### DIFF
--- a/libbzip2-rs-sys/src/allocator.rs
+++ b/libbzip2-rs-sys/src/allocator.rs
@@ -14,6 +14,8 @@
 //! point where we deallocate it.
 use core::ffi::{c_int, c_void};
 
+use crate::bzlib::{BzStream, StreamState};
+
 type AllocFunc = unsafe extern "C" fn(*mut c_void, c_int, c_int) -> *mut c_void;
 type FreeFunc = unsafe extern "C" fn(*mut c_void, *mut c_void) -> ();
 
@@ -58,7 +60,7 @@ impl Allocator {
     ///     * a `NULL` pointer
     ///     * a valid pointer to an allocation of `len * size_of::<T>()` bytes aligned to at least `align_of::<usize>()`
     /// - `strm.bzfree` frees memory allocated by `strm.bzalloc`
-    pub(crate) unsafe fn from_bz_stream(strm: &crate::bz_stream) -> Option<Self> {
+    pub(crate) unsafe fn from_bz_stream<S: StreamState>(strm: &BzStream<S>) -> Option<Self> {
         let bzalloc = strm.bzalloc?;
         let bzfree = strm.bzfree?;
 

--- a/libbzip2-rs-sys/src/allocator.rs
+++ b/libbzip2-rs-sys/src/allocator.rs
@@ -102,12 +102,14 @@ pub(crate) mod c_allocator {
     pub(crate) static ALLOCATOR: (AllocFunc, FreeFunc) = (self::allocate, self::deallocate);
 
     unsafe extern "C" fn allocate(_opaque: *mut c_void, count: c_int, size: c_int) -> *mut c_void {
-        libc::malloc((count * size) as usize)
+        unsafe { libc::malloc((count * size) as usize) }
     }
 
     unsafe extern "C" fn deallocate(_opaque: *mut c_void, ptr: *mut c_void) {
         if !ptr.is_null() {
-            libc::free(ptr);
+            unsafe {
+                libc::free(ptr);
+            }
         }
     }
 }

--- a/libbzip2-rs-sys/src/bzlib.rs
+++ b/libbzip2-rs-sys/src/bzlib.rs
@@ -349,9 +349,9 @@ impl Arr2 {
         let block = unsafe { core::slice::from_raw_parts_mut(self.ptr.cast(), len) };
 
         let start_byte = len.next_multiple_of(2);
-        let quadrant: *mut u16 = (self.ptr as *mut u8).wrapping_add(start_byte) as *mut u16;
-        unsafe { ptr::write_bytes(quadrant, 0, len) };
+        let quadrant: *mut u16 = unsafe { self.ptr.cast::<u16>().byte_add(start_byte) };
         let quadrant = unsafe { core::slice::from_raw_parts_mut(quadrant, len) };
+        quadrant.fill(0);
 
         (block, quadrant)
     }

--- a/libbzip2-rs-sys/src/bzlib.rs
+++ b/libbzip2-rs-sys/src/bzlib.rs
@@ -275,7 +275,7 @@ mod stream {
     pub(super) fn configure_allocator<S: StreamState>(strm: &mut BzStream<S>) -> Option<Allocator> {
         match (strm.bzalloc, strm.bzfree) {
             (Some(allocate), Some(deallocate)) => {
-                Some(Allocator::custom(allocate, deallocate, (*strm).opaque))
+                Some(Allocator::custom(allocate, deallocate, strm.opaque))
             }
             (None, None) => {
                 let allocator = Allocator::DEFAULT?;
@@ -745,12 +745,12 @@ pub(crate) fn BZ2_bzCompressInitHelp(
         (*s).workFactor = workFactor;
     }
 
-    (*strm).state = s as *mut EState;
+    strm.state = s;
 
-    (*strm).total_in_lo32 = 0;
-    (*strm).total_in_hi32 = 0;
-    (*strm).total_out_lo32 = 0;
-    (*strm).total_out_hi32 = 0;
+    strm.total_in_lo32 = 0;
+    strm.total_in_hi32 = 0;
+    strm.total_out_lo32 = 0;
+    strm.total_out_hi32 = 0;
 
     let s = unsafe { &mut *s };
     init_rl(&mut *s);
@@ -1194,12 +1194,12 @@ pub(crate) fn BZ2_bzDecompressInitHelp(
         (*s).verbosity = verbosity;
     }
 
-    (*strm).state = s as *mut DState;
+    strm.state = s;
 
-    (*strm).total_in_lo32 = 0;
-    (*strm).total_in_hi32 = 0;
-    (*strm).total_out_lo32 = 0;
-    (*strm).total_out_hi32 = 0;
+    strm.total_in_lo32 = 0;
+    strm.total_in_hi32 = 0;
+    strm.total_out_lo32 = 0;
+    strm.total_out_hi32 = 0;
 
     ReturnCode::BZ_OK
 }

--- a/libbzip2-rs-sys/src/decompress.rs
+++ b/libbzip2-rs-sys/src/decompress.rs
@@ -3,7 +3,7 @@
 use core::ffi::{c_int, c_uint};
 
 use crate::allocator::Allocator;
-use crate::bzlib::{bz_stream, index_into_f, DSlice, DState, DecompressMode, ReturnCode};
+use crate::bzlib::{index_into_f, BzStream, DSlice, DState, DecompressMode, ReturnCode};
 use crate::huffman;
 use crate::randtable::BZ2_RNUMS;
 
@@ -157,7 +157,7 @@ impl GetBitsConvert for i32 {
 }
 
 pub(crate) fn decompress(
-    strm: &mut bz_stream,
+    strm: &mut BzStream<DState>,
     s: &mut DState,
     allocator: &Allocator,
 ) -> ReturnCode {

--- a/libbzip2-rs-sys/src/high_level.rs
+++ b/libbzip2-rs-sys/src/high_level.rs
@@ -1,3 +1,5 @@
+#![allow(unsafe_op_in_unsafe_fn)]
+
 use core::ffi::{c_char, c_int, c_uint, c_void, CStr};
 use core::{mem, ptr};
 

--- a/libbzip2-rs-sys/src/lib.rs
+++ b/libbzip2-rs-sys/src/lib.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::needless_range_loop)] // FIXME remove once all instances are fixed
 #![deny(unreachable_pub)]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 //! A drop-in compatible rust implementation of bzip2
 


### PR DESCRIPTION
Among other things this introduces the `BzStream<S>` type which has an identical layout to `bz_stream`, but is guaranteed to contain a state pointer of type `S` and have valid allocator fields. While we can't actually check for full correctness when C code does funky things, this does enable us to assign blame to the C code and avoid having to use unsafe code everywhere to access the compression/decompression state and the allocator.