### PR TITLE
Use panics in handle_assert_failure too when stdio mode is disabled

### DIFF
--- a/libbz2-rs-sys/src/lib.rs
+++ b/libbz2-rs-sys/src/lib.rs
@@ -137,26 +137,13 @@ macro_rules! assert_h {
 
 #[cold]
 fn handle_assert_failure(errcode: c_int) -> ! {
-    #[cfg(feature = "stdio")]
-    {
-        #[cfg(feature = "std")]
-        std::eprint!("{}", AssertFail(errcode));
-        #[cfg(feature = "std")]
-        std::process::exit(3);
+    #[cfg(feature = "std")]
+    std::eprint!("{}", AssertFail(errcode));
+    #[cfg(feature = "std")]
+    std::process::exit(3);
 
-        #[cfg(not(feature = "std"))]
-        panic!("{}", AssertFail(errcode));
-    }
-
-    #[cfg(not(feature = "stdio"))]
-    {
-        extern "C" {
-            fn bz_internal_error(errcode: c_int);
-        }
-
-        unsafe { bz_internal_error(errcode) }
-        loop {}
-    }
+    #[cfg(not(feature = "std"))]
+    panic!("{}", AssertFail(errcode));
 }
 
 use assert_h;


### PR DESCRIPTION
When using libbz2-rs-sys as a rust dependency, it is not possible to define bz_internal_error in a way that GNU ld will accept. The definition would come before the use in libbz2-rs-sys and GNU ld will only resolve symbol uses when the defining static library comes after the static library that needs the symbol.

When using as cdylib bz_internal_error will still be called by the panic handler in libbz2-rs-sys-cdylib.