### PR TITLE
refactors in `un_rle_obuf_to_output_fast`

### DIFF
--- a/libbz2-rs-sys/src/bzlib.rs
+++ b/libbz2-rs-sys/src/bzlib.rs
@@ -1428,7 +1428,6 @@ fn un_rle_obuf_to_output_fast(strm: &mut BzStream<DState>, s: &mut DState) -> bo
 
                 if k1 as i32 != c_k0 {
                     c_k0 = k1 as i32;
-
                     continue 'return_notr;
                 }
 
@@ -1451,7 +1450,7 @@ fn un_rle_obuf_to_output_fast(strm: &mut BzStream<DState>, s: &mut DState) -> bo
                 BZ_GET_FAST_C!(c_k0);
                 c_nblock_used += 1;
 
-                break;
+                continue 'return_notr;
             }
         }
 

--- a/libbz2-rs-sys/src/bzlib.rs
+++ b/libbz2-rs-sys/src/bzlib.rs
@@ -1369,7 +1369,7 @@ fn un_rle_obuf_to_output_fast(strm: &mut BzStream<DState>, s: &mut DState) -> bo
             }
 
             if c_state_out_len > 0 {
-                let bound = Ord::min(cs_avail_out, c_state_out_len - 1);
+                let bound = Ord::min(cs_avail_out, c_state_out_len);
 
                 unsafe {
                     core::ptr::write_bytes(cs_next_out as *mut u8, c_state_out_ch, bound as usize);
@@ -1386,9 +1386,6 @@ fn un_rle_obuf_to_output_fast(strm: &mut BzStream<DState>, s: &mut DState) -> bo
                 if cs_avail_out == 0 {
                     break 'return_notr;
                 }
-
-                out_len_eq_one!();
-            } else {
             }
 
             loop {

--- a/libbz2-rs-sys/src/bzlib.rs
+++ b/libbz2-rs-sys/src/bzlib.rs
@@ -1388,68 +1388,66 @@ fn un_rle_obuf_to_output_fast(strm: &mut BzStream<DState>, s: &mut DState) -> bo
             }
 
             loop {
-                {
-                    /* Only caused by corrupt data stream? */
-                    if c_nblock_used > s_save_nblockPP {
-                        return true;
-                    }
-
-                    /* can a new run be started? */
-                    if c_nblock_used == s_save_nblockPP {
-                        c_state_out_len = 0;
-                        break 'return_notr;
-                    }
-
-                    c_state_out_ch = c_k0 as u8;
-                    BZ_GET_FAST_C!(k1);
-                    c_nblock_used += 1;
-
-                    if k1 as i32 != c_k0 {
-                        c_k0 = k1 as i32;
-                        out_len_eq_one!();
-                        continue;
-                    }
-
-                    if c_nblock_used == s_save_nblockPP {
-                        out_len_eq_one!();
-                        continue;
-                    }
-
-                    c_state_out_len = 2;
-                    BZ_GET_FAST_C!(k1);
-                    c_nblock_used += 1;
-
-                    if c_nblock_used == s_save_nblockPP {
-                        continue 'return_notr;
-                    }
-
-                    if k1 as i32 != c_k0 {
-                        c_k0 = k1 as i32;
-
-                        continue 'return_notr;
-                    }
-
-                    c_state_out_len = 3;
-                    BZ_GET_FAST_C!(k1);
-                    c_nblock_used += 1;
-
-                    if c_nblock_used == s_save_nblockPP {
-                        continue 'return_notr;
-                    }
-
-                    if k1 as i32 != c_k0 {
-                        c_k0 = k1 as i32;
-                        continue 'return_notr;
-                    }
-
-                    BZ_GET_FAST_C!(k1);
-                    c_nblock_used += 1;
-                    c_state_out_len = k1 as u32 + 4;
-                    BZ_GET_FAST_C!(c_k0);
-                    c_nblock_used += 1;
-
-                    break;
+                /* Only caused by corrupt data stream? */
+                if c_nblock_used > s_save_nblockPP {
+                    return true;
                 }
+
+                /* can a new run be started? */
+                if c_nblock_used == s_save_nblockPP {
+                    c_state_out_len = 0;
+                    break 'return_notr;
+                }
+
+                c_state_out_ch = c_k0 as u8;
+                BZ_GET_FAST_C!(k1);
+                c_nblock_used += 1;
+
+                if k1 as i32 != c_k0 {
+                    c_k0 = k1 as i32;
+                    out_len_eq_one!();
+                    continue;
+                }
+
+                if c_nblock_used == s_save_nblockPP {
+                    out_len_eq_one!();
+                    continue;
+                }
+
+                c_state_out_len = 2;
+                BZ_GET_FAST_C!(k1);
+                c_nblock_used += 1;
+
+                if c_nblock_used == s_save_nblockPP {
+                    continue 'return_notr;
+                }
+
+                if k1 as i32 != c_k0 {
+                    c_k0 = k1 as i32;
+
+                    continue 'return_notr;
+                }
+
+                c_state_out_len = 3;
+                BZ_GET_FAST_C!(k1);
+                c_nblock_used += 1;
+
+                if c_nblock_used == s_save_nblockPP {
+                    continue 'return_notr;
+                }
+
+                if k1 as i32 != c_k0 {
+                    c_k0 = k1 as i32;
+                    continue 'return_notr;
+                }
+
+                BZ_GET_FAST_C!(k1);
+                c_nblock_used += 1;
+                c_state_out_len = k1 as u32 + 4;
+                BZ_GET_FAST_C!(c_k0);
+                c_nblock_used += 1;
+
+                break;
             }
         }
 

--- a/libbz2-rs-sys/src/bzlib.rs
+++ b/libbz2-rs-sys/src/bzlib.rs
@@ -1350,9 +1350,10 @@ fn un_rle_obuf_to_output_fast(strm: &mut BzStream<DState>, s: &mut DState) -> bo
             ( $cccc:expr) => {
                 /* c_tPos is unsigned, hence test < 0 is pointless. */
                 if c_tPos >= 100000u32.wrapping_mul(ro_blockSize100k as u32) {
+                    // return corrupt if we're past the length of the block
                     return true;
                 }
-                c_tPos = s.tt.as_slice()[c_tt..][c_tPos as usize];
+                c_tPos = s.tt.as_slice()[c_tt + c_tPos as usize];
                 $cccc = (c_tPos & 0xff) as _;
                 c_tPos >>= 8;
             };

--- a/libbz2-rs-sys/src/bzlib.rs
+++ b/libbz2-rs-sys/src/bzlib.rs
@@ -522,7 +522,7 @@ pub(crate) struct DState {
     pub strm_addr: usize, // Only for a consistency check
     pub state: decompress::State,
     pub state_out_ch: u8,
-    pub state_out_len: i32,
+    pub state_out_len: u32,
     pub blockRandomised: bool,
     pub rNToGo: i32,
     pub rTPos: i32,
@@ -1317,7 +1317,7 @@ fn un_rle_obuf_to_output_fast(strm: &mut BzStream<DState>, s: &mut DState) -> bo
             BZ_RAND_UPD_MASK!(s);
             k1 ^= BZ_RAND_MASK!(s);
             s.nblock_used += 1;
-            s.state_out_len = k1 as i32 + 4;
+            s.state_out_len = k1 as u32 + 4;
             BZ_GET_FAST!(s, s.k0);
             BZ_RAND_UPD_MASK!(s);
             s.k0 ^= BZ_RAND_MASK!(s) as i32;
@@ -1333,7 +1333,7 @@ fn un_rle_obuf_to_output_fast(strm: &mut BzStream<DState>, s: &mut DState) -> bo
         /* restore */
         let mut c_calculatedBlockCRC: u32 = s.calculatedBlockCRC;
         let mut c_state_out_ch: u8 = s.state_out_ch;
-        let mut c_state_out_len: i32 = s.state_out_len;
+        let mut c_state_out_len: u32 = s.state_out_len;
         let mut c_nblock_used: i32 = s.nblock_used;
         let mut c_k0: i32 = s.k0;
         let c_tt = 0usize;
@@ -1449,7 +1449,7 @@ fn un_rle_obuf_to_output_fast(strm: &mut BzStream<DState>, s: &mut DState) -> bo
 
                         BZ_GET_FAST_C!(k1);
                         c_nblock_used += 1;
-                        c_state_out_len = k1 as i32 + 4;
+                        c_state_out_len = k1 as u32 + 4;
                         BZ_GET_FAST_C!(c_k0);
                         c_nblock_used += 1;
 
@@ -1596,7 +1596,7 @@ fn un_rle_obuf_to_output_small(strm: &mut BzStream<DState>, s: &mut DState) -> b
             BZ_RAND_UPD_MASK!(s);
             k1 ^= BZ_RAND_MASK!(s);
             s.nblock_used += 1;
-            s.state_out_len = k1 as i32 + 4;
+            s.state_out_len = k1 as u32 + 4;
             BZ_GET_SMALL!(s, s.k0);
             BZ_RAND_UPD_MASK!(s);
             s.k0 ^= BZ_RAND_MASK!(s) as i32;
@@ -1661,7 +1661,7 @@ fn un_rle_obuf_to_output_small(strm: &mut BzStream<DState>, s: &mut DState) -> b
 
             BZ_GET_SMALL!(s, k1);
             s.nblock_used += 1;
-            s.state_out_len = k1 as i32 + 4;
+            s.state_out_len = k1 as u32 + 4;
             BZ_GET_SMALL!(s, s.k0);
             s.nblock_used += 1;
         }

--- a/libbz2-rs-sys/src/bzlib.rs
+++ b/libbz2-rs-sys/src/bzlib.rs
@@ -1330,7 +1330,6 @@ fn un_rle_obuf_to_output_fast(strm: &mut BzStream<DState>, s: &mut DState) -> bo
         let mut c_state_out_len: u32 = s.state_out_len;
         let mut c_nblock_used: i32 = s.nblock_used;
         let mut c_k0: i32 = s.k0;
-        let c_tt = 0usize;
         let mut c_tPos: u32 = s.tPos;
         let mut cs_next_out: *mut c_char = strm.next_out;
         let mut cs_avail_out: c_uint = strm.avail_out;
@@ -1347,7 +1346,7 @@ fn un_rle_obuf_to_output_fast(strm: &mut BzStream<DState>, s: &mut DState) -> bo
                     // return corrupt if we're past the length of the block
                     return true;
                 }
-                c_tPos = s.tt.as_slice()[c_tt + c_tPos as usize];
+                c_tPos = s.tt.as_slice()[c_tPos as usize];
                 $cccc = (c_tPos & 0xff) as _;
                 c_tPos >>= 8;
             };
@@ -1466,7 +1465,6 @@ fn un_rle_obuf_to_output_fast(strm: &mut BzStream<DState>, s: &mut DState) -> bo
         s.state_out_len = c_state_out_len;
         s.nblock_used = c_nblock_used;
         s.k0 = c_k0;
-        // s.tt = c_tt; // as far as I can tell, this value is never actually updated
         s.tPos = c_tPos;
         strm.next_out = cs_next_out;
         strm.avail_out = cs_avail_out;

--- a/libbz2-rs-sys/src/bzlib.rs
+++ b/libbz2-rs-sys/src/bzlib.rs
@@ -1473,7 +1473,7 @@ fn un_rle_obuf_to_output_fast(strm: &mut BzStream<DState>, s: &mut DState) -> bo
 }
 
 #[inline]
-pub(crate) fn index_into_f(indx: i32, cftab: &mut [i32]) -> i32 {
+pub(crate) fn index_into_f(indx: i32, cftab: &[i32; 257]) -> i32 {
     let mut nb = 0;
     let mut na = 256;
     loop {

--- a/libbz2-rs-sys/src/bzlib.rs
+++ b/libbz2-rs-sys/src/bzlib.rs
@@ -1362,7 +1362,7 @@ fn un_rle_obuf_to_output_fast(strm: &mut BzStream<DState>, s: &mut DState) -> bo
                     } else {
                         unsafe { *(cs_next_out as *mut u8) = c_state_out_ch };
                         BZ_UPDATE_CRC!(c_calculatedBlockCRC, c_state_out_ch);
-                        cs_next_out = unsafe { cs_next_out.offset(1) };
+                        cs_next_out = unsafe { cs_next_out.add(1) };
                         cs_avail_out -= 1;
                     }
                 };

--- a/libbz2-rs-sys/src/decompress.rs
+++ b/libbz2-rs-sys/src/decompress.rs
@@ -1119,7 +1119,7 @@ pub(crate) fn decompress(
                                             // `return true` is probably uninitentional?!
                                             return ReturnCode::BZ_RUN_OK;
                                         }
-                                        s.k0 = index_into_f(s.tPos as i32, &mut s.cftab);
+                                        s.k0 = index_into_f(s.tPos as i32, &s.cftab);
                                         s.tPos = ll16[s.tPos as usize] as u32
                                             | (ll4[(s.tPos >> 1) as usize] as u32
                                                 >> (s.tPos << 2 & 0x4)
@@ -1142,7 +1142,7 @@ pub(crate) fn decompress(
                                             // `return true` is probably uninitentional?!
                                             return ReturnCode::BZ_RUN_OK;
                                         }
-                                        s.k0 = index_into_f(s.tPos as i32, &mut s.cftab);
+                                        s.k0 = index_into_f(s.tPos as i32, &s.cftab);
                                         s.tPos = ll16[s.tPos as usize] as u32
                                             | (ll4[(s.tPos >> 1) as usize] as u32
                                                 >> (s.tPos << 2 & 0x4)

--- a/libbz2-rs-sys/src/decompress.rs
+++ b/libbz2-rs-sys/src/decompress.rs
@@ -1155,8 +1155,7 @@ pub(crate) fn decompress(
                                     i = 0;
                                     while i < nblock {
                                         uc = (tt[i as usize] & 0xff) as u8;
-                                        let fresh0 = &mut (tt[s.cftab[uc as usize] as usize]);
-                                        *fresh0 |= (i << 8) as c_uint;
+                                        tt[s.cftab[uc as usize] as usize] |= (i << 8) as c_uint;
                                         s.cftab[uc as usize] += 1;
                                         i += 1;
                                     }


### PR DESCRIPTION
Especially for larger files, it turns out that this function is very hot. E.g. for the `tests/input/bzip2-testfiles/go/regexp/re2-exhaustive.txt.bz2` input file, 80% of total time is spent here (and only 14% in the actual `decompress` function). I also suspect that there is something else going on, perhaps the compression level/block size?

This is an attempt to make this function faster, so far without much success. But I think these changes are nice anyway, and hopefully make the structure clear enough to crack this nut. Currently wall time is unchanged, but instruction count is decreased for some of the input files. 

Best reviewed commit-by-commit