### PR TITLE
cleanups

### DIFF
--- a/libbz2-rs-sys/src/bzlib.rs
+++ b/libbz2-rs-sys/src/bzlib.rs
@@ -1237,6 +1237,8 @@ macro_rules! BZ_RAND_UPD_MASK {
     };
 }
 
+pub(crate) use BZ_RAND_UPD_MASK;
+
 macro_rules! BZ_GET_FAST {
     ($s:expr, $cccc:expr) => {
         /* c_tPos is unsigned, hence test < 0 is pointless. */

--- a/libbz2-rs-sys/src/bzlib.rs
+++ b/libbz2-rs-sys/src/bzlib.rs
@@ -522,25 +522,26 @@ impl Ftab {
     }
 }
 
+#[repr(C)]
 pub(crate) struct DState {
     pub strm_addr: usize, // Only for a consistency check
     pub state: decompress::State,
-    pub state_out_ch: u8,
     pub state_out_len: u32,
+    pub state_out_ch: u8,
     pub blockRandomised: bool,
+    pub blockSize100k: u8,
+    pub k0: u8,
     pub rNToGo: i32,
     pub rTPos: i32,
     pub bsBuff: u32,
     pub bsLive: i32,
-    pub blockSize100k: i32,
     pub smallDecompress: DecompressMode,
     pub currBlockNo: i32,
     pub verbosity: i32,
     pub origPtr: i32,
     pub tPos: u32,
-    pub k0: u8,
-    pub unzftab: [i32; 256],
     pub nblock_used: i32,
+    pub unzftab: [i32; 256],
     pub cftab: [i32; 257],
     pub cftabCopy: [i32; 257],
     pub tt: DSlice<u32>,
@@ -1339,13 +1340,13 @@ fn un_rle_obuf_to_output_fast(strm: &mut BzStream<DState>, s: &mut DState) -> bo
         let mut c_tPos: u32 = s.tPos;
         let mut cs_next_out: *mut c_char = strm.next_out;
         let mut cs_avail_out: c_uint = strm.avail_out;
-        let ro_blockSize100k: i32 = s.blockSize100k;
+        let ro_blockSize100k: u8 = s.blockSize100k;
         /* end restore */
 
         let avail_out_INIT: u32 = cs_avail_out;
         let s_save_nblockPP: i32 = s.save.nblock as i32 + 1;
 
-        let tt = &s.tt.as_slice()[..100000usize.wrapping_mul(ro_blockSize100k as usize)];
+        let tt = &s.tt.as_slice()[..100000usize.wrapping_mul(usize::from(ro_blockSize100k))];
 
         macro_rules! BZ_GET_FAST_C {
             ($c_tPos:expr) => {

--- a/libbz2-rs-sys/src/bzlib.rs
+++ b/libbz2-rs-sys/src/bzlib.rs
@@ -575,7 +575,7 @@ pub(crate) struct SaveArea {
     pub EOB: u16,
     pub groupNo: i32,
     pub nblock: u32,
-    pub es: i32,
+    pub es: u32,
     pub zvec: i32,
     pub nextSym: u16,
     pub nSelectors: u16,

--- a/libbz2-rs-sys/src/decompress.rs
+++ b/libbz2-rs-sys/src/decompress.rs
@@ -786,7 +786,6 @@ pub(crate) fn decompress(
                             s.unzftab[usize::from(uc)] += es as i32;
                             match s.smallDecompress {
                                 DecompressMode::Small => {
-                                    let ll16 = &mut ll16[..100000 * usize::from(nblockMAX100k)];
                                     match ll16.get_mut(nblock as usize..(nblock + es) as usize) {
                                         Some(slice) => slice.fill(u16::from(uc)),
                                         None => error!(BZ_DATA_ERROR),
@@ -794,7 +793,6 @@ pub(crate) fn decompress(
                                     nblock += es;
                                 }
                                 DecompressMode::Fast => {
-                                    let tt = &mut tt[..100000 * usize::from(nblockMAX100k)];
                                     match tt.get_mut(nblock as usize..(nblock + es) as usize) {
                                         Some(slice) => slice.fill(u32::from(uc)),
                                         None => error!(BZ_DATA_ERROR),

--- a/libbz2-rs-sys/src/decompress.rs
+++ b/libbz2-rs-sys/src/decompress.rs
@@ -782,30 +782,24 @@ pub(crate) fn decompress(
                         if nextSym == BZ_RUNA || nextSym == BZ_RUNB {
                             current_block = Block46;
                         } else {
-                            uc = s.seqToUnseq[s.mtfa[s.mtfbase[0_usize] as usize] as usize];
-                            s.unzftab[uc as usize] += es as i32;
+                            let uc = s.seqToUnseq[s.mtfa[s.mtfbase[0_usize] as usize] as usize];
+                            s.unzftab[usize::from(uc)] += es as i32;
                             match s.smallDecompress {
                                 DecompressMode::Small => {
-                                    while es > 0 {
-                                        if nblock >= 100000 * nblockMAX100k as u32 {
-                                            error!(BZ_DATA_ERROR);
-                                        } else {
-                                            ll16[nblock as usize] = uc as u16;
-                                            nblock += 1;
-                                            es -= 1;
-                                        }
-                                    }
+                                    let ll16 = &mut ll16[..100000 * usize::from(nblockMAX100k)];
+                                    match ll16.get_mut(nblock as usize..(nblock + es) as usize) {
+                                        Some(slice) => slice.fill(u16::from(uc)),
+                                        None => error!(BZ_DATA_ERROR),
+                                    };
+                                    nblock += es;
                                 }
                                 DecompressMode::Fast => {
-                                    while es > 0 {
-                                        if nblock >= 100000 * nblockMAX100k as u32 {
-                                            error!(BZ_DATA_ERROR);
-                                        } else {
-                                            tt[nblock as usize] = uc as u32;
-                                            nblock += 1;
-                                            es -= 1;
-                                        }
-                                    }
+                                    let tt = &mut tt[..100000 * usize::from(nblockMAX100k)];
+                                    match tt.get_mut(nblock as usize..(nblock + es) as usize) {
+                                        Some(slice) => slice.fill(u32::from(uc)),
+                                        None => error!(BZ_DATA_ERROR),
+                                    };
+                                    nblock += es;
                                 }
                             }
                             current_block = Block40;
@@ -841,7 +835,7 @@ pub(crate) fn decompress(
                     es = 0;
                     logN = 0;
                     current_block = Block46;
-                } else if nblock >= 100000 * nblockMAX100k as u32 {
+                } else if nblock >= 100000 * u32::from(nblockMAX100k) {
                     error!(BZ_DATA_ERROR);
                 } else {
                     let uc = usize::from(initialize_mtfa(&mut s.mtfa, &mut s.mtfbase, nextSym));

--- a/libbz2-rs-sys/src/decompress.rs
+++ b/libbz2-rs-sys/src/decompress.rs
@@ -783,7 +783,7 @@ pub(crate) fn decompress(
                             current_block = Block46;
                         } else {
                             uc = s.seqToUnseq[s.mtfa[s.mtfbase[0_usize] as usize] as usize];
-                            s.unzftab[uc as usize] += es;
+                            s.unzftab[uc as usize] += es as i32;
                             match s.smallDecompress {
                                 DecompressMode::Small => {
                                     while es > 0 {

--- a/libbz2-rs-sys/src/decompress.rs
+++ b/libbz2-rs-sys/src/decompress.rs
@@ -317,13 +317,13 @@ pub(crate) fn decompress(
             match s.smallDecompress {
                 DecompressMode::Small => {
                     // SAFETY: we assume allocation is safe
-                    let ll16_len = s.blockSize100k as usize * 100000;
+                    let ll16_len = usize::from(s.blockSize100k) * 100000;
                     let Some(ll16) = DSlice::alloc(allocator, ll16_len) else {
                         error!(BZ_MEM_ERROR);
                     };
 
                     // SAFETY: we assume allocation is safe
-                    let ll4_len = (1 + s.blockSize100k as usize * 100000) >> 1;
+                    let ll4_len = (1 + usize::from(s.blockSize100k) * 100000) >> 1;
                     let Some(ll4) = DSlice::alloc(allocator, ll4_len) else {
                         error!(BZ_MEM_ERROR);
                     };
@@ -333,7 +333,7 @@ pub(crate) fn decompress(
                 }
                 DecompressMode::Fast => {
                     // SAFETY: we assume allocation is safe
-                    let tt_len = s.blockSize100k as usize * 100000;
+                    let tt_len = usize::from(s.blockSize100k) * 100000;
                     let Some(tt) = DSlice::alloc(allocator, tt_len) else {
                         error!(BZ_MEM_ERROR);
                     };
@@ -1177,7 +1177,7 @@ pub(crate) fn decompress(
                     /*--- Now the MTF values ---*/
 
                     EOB = s.nInUse + 1;
-                    nblockMAX100k = s.blockSize100k as u8;
+                    nblockMAX100k = s.blockSize100k;
                     s.unzftab.fill(0);
 
                     /*-- MTF init --*/

--- a/libbz2-rs-sys/src/decompress.rs
+++ b/libbz2-rs-sys/src/decompress.rs
@@ -306,13 +306,13 @@ pub(crate) fn decompress(
         if current_block == BZ_X_MAGIC_4 {
             s.state = State::BZ_X_MAGIC_4;
 
-            s.blockSize100k = GET_BYTE!(strm, s) as i32;
+            s.blockSize100k = GET_BYTE!(strm, s);
 
-            if !(b'1' as i32..=b'9' as i32).contains(&s.blockSize100k) {
+            if !(b'1'..=b'9').contains(&s.blockSize100k) {
                 error!(BZ_DATA_ERROR_MAGIC);
             }
 
-            s.blockSize100k -= b'0' as i32;
+            s.blockSize100k -= b'0';
 
             match s.smallDecompress {
                 DecompressMode::Small => {
@@ -592,7 +592,7 @@ pub(crate) fn decompress(
             uc = GET_BYTE!(strm, s);
 
             s.origPtr = s.origPtr << 8 | i32::from(uc);
-            if !(0..10 + 100000 * s.blockSize100k).contains(&s.origPtr) {
+            if !(0..10 + 100000 * i32::from(s.blockSize100k)).contains(&s.origPtr) {
                 error!(BZ_DATA_ERROR);
             }
 
@@ -879,6 +879,8 @@ pub(crate) fn decompress(
                             if s.verbosity >= 2 {
                                 debug_log!("rt+rld");
                             }
+                            let max_block_size =
+                                100000_u32.wrapping_mul(u32::from(s.blockSize100k));
                             match s.smallDecompress {
                                 DecompressMode::Small => {
                                     // Make a copy of cftab, used in generation of T
@@ -934,8 +936,7 @@ pub(crate) fn decompress(
                                     if s.blockRandomised {
                                         s.rNToGo = 0;
                                         s.rTPos = 0;
-                                        if s.tPos >= 100000_u32.wrapping_mul(s.blockSize100k as u32)
-                                        {
+                                        if s.tPos >= max_block_size {
                                             // NOTE: this originates in the BZ_GET_FAST macro, and the
                                             // `return true` is probably uninitentional?!
                                             return ReturnCode::BZ_RUN_OK;
@@ -957,8 +958,7 @@ pub(crate) fn decompress(
                                         s.rNToGo -= 1;
                                         s.k0 ^= if s.rNToGo == 1 { 1 } else { 0 };
                                     } else {
-                                        if s.tPos >= 100000_u32.wrapping_mul(s.blockSize100k as u32)
-                                        {
+                                        if s.tPos >= max_block_size {
                                             // NOTE: this originates in the BZ_GET_FAST macro, and the
                                             // `return true` is probably uninitentional?!
                                             return ReturnCode::BZ_RUN_OK;
@@ -983,8 +983,7 @@ pub(crate) fn decompress(
                                     if s.blockRandomised {
                                         s.rNToGo = 0;
                                         s.rTPos = 0;
-                                        if s.tPos >= 100000_u32.wrapping_mul(s.blockSize100k as u32)
-                                        {
+                                        if s.tPos >= max_block_size {
                                             // NOTE: this originates in the BZ_GET_FAST macro, and the
                                             // `return true` is probably uninitentional?!
                                             return ReturnCode::BZ_RUN_OK;
@@ -1003,8 +1002,7 @@ pub(crate) fn decompress(
                                         s.rNToGo -= 1;
                                         s.k0 ^= if s.rNToGo == 1 { 1 } else { 0 };
                                     } else {
-                                        if s.tPos >= 100000_u32.wrapping_mul(s.blockSize100k as u32)
-                                        {
+                                        if s.tPos >= max_block_size {
                                             // NOTE: this originates in the BZ_GET_FAST macro, and the
                                             // `return true` is probably uninitentional?!
                                             return ReturnCode::BZ_RUN_OK;

--- a/libbz2-rs-sys/src/decompress.rs
+++ b/libbz2-rs-sys/src/decompress.rs
@@ -782,7 +782,6 @@ pub(crate) fn decompress(
                         if nextSym == BZ_RUNA || nextSym == BZ_RUNB {
                             current_block = Block46;
                         } else {
-                            es += 1;
                             uc = s.seqToUnseq[s.mtfa[s.mtfbase[0_usize] as usize] as usize];
                             s.unzftab[uc as usize] += es;
                             match s.smallDecompress {
@@ -839,7 +838,7 @@ pub(crate) fn decompress(
                 if nextSym == EOB {
                     current_block = Block41;
                 } else if nextSym == BZ_RUNA || nextSym == BZ_RUNB {
-                    es = -1;
+                    es = 0;
                     logN = 0;
                     current_block = Block46;
                 } else if nblock >= 100000 * nblockMAX100k as u32 {


### PR DESCRIPTION
- we missed a macro that cuts down on the line count
- by moving the branch on whether `blockRandomized` is true we can deduplicate code
- some state fields can be smaller/unsigned