### PR TITLE
Speedup compress

### DIFF
--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -415,102 +415,21 @@ fn mainGtU(
 
     k = nblock.wrapping_add(8 as c_int as c_uint) as i32;
     loop {
-        c1 = block[i1 as usize];
-        c2 = block[i2 as usize];
-        if c1 != c2 {
-            return c1 > c2;
+        for _ in 0..8 {
+            c1 = block[i1 as usize];
+            c2 = block[i2 as usize];
+            if c1 != c2 {
+                return c1 > c2;
+            }
+            s1 = quadrant[i1 as usize];
+            s2 = quadrant[i2 as usize];
+            if s1 != s2 {
+                return s1 > s2;
+            }
+            i1 = i1.wrapping_add(1);
+            i2 = i2.wrapping_add(1);
         }
-        s1 = quadrant[i1 as usize];
-        s2 = quadrant[i2 as usize];
-        if s1 != s2 {
-            return s1 > s2;
-        }
-        i1 = i1.wrapping_add(1);
-        i2 = i2.wrapping_add(1);
-        c1 = block[i1 as usize];
-        c2 = block[i2 as usize];
-        if c1 != c2 {
-            return c1 > c2;
-        }
-        s1 = quadrant[i1 as usize];
-        s2 = quadrant[i2 as usize];
-        if s1 != s2 {
-            return s1 > s2;
-        }
-        i1 = i1.wrapping_add(1);
-        i2 = i2.wrapping_add(1);
-        c1 = block[i1 as usize];
-        c2 = block[i2 as usize];
-        if c1 != c2 {
-            return c1 > c2;
-        }
-        s1 = quadrant[i1 as usize];
-        s2 = quadrant[i2 as usize];
-        if s1 != s2 {
-            return s1 > s2;
-        }
-        i1 = i1.wrapping_add(1);
-        i2 = i2.wrapping_add(1);
-        c1 = block[i1 as usize];
-        c2 = block[i2 as usize];
-        if c1 != c2 {
-            return c1 > c2;
-        }
-        s1 = quadrant[i1 as usize];
-        s2 = quadrant[i2 as usize];
-        if s1 != s2 {
-            return s1 > s2;
-        }
-        i1 = i1.wrapping_add(1);
-        i2 = i2.wrapping_add(1);
-        c1 = block[i1 as usize];
-        c2 = block[i2 as usize];
-        if c1 != c2 {
-            return c1 > c2;
-        }
-        s1 = quadrant[i1 as usize];
-        s2 = quadrant[i2 as usize];
-        if s1 != s2 {
-            return s1 > s2;
-        }
-        i1 = i1.wrapping_add(1);
-        i2 = i2.wrapping_add(1);
-        c1 = block[i1 as usize];
-        c2 = block[i2 as usize];
-        if c1 != c2 {
-            return c1 > c2;
-        }
-        s1 = quadrant[i1 as usize];
-        s2 = quadrant[i2 as usize];
-        if s1 != s2 {
-            return s1 > s2;
-        }
-        i1 = i1.wrapping_add(1);
-        i2 = i2.wrapping_add(1);
-        c1 = block[i1 as usize];
-        c2 = block[i2 as usize];
-        if c1 != c2 {
-            return c1 > c2;
-        }
-        s1 = quadrant[i1 as usize];
-        s2 = quadrant[i2 as usize];
-        if s1 != s2 {
-            return s1 > s2;
-        }
-        i1 = i1.wrapping_add(1);
-        i2 = i2.wrapping_add(1);
-        c1 = block[i1 as usize];
-        c2 = block[i2 as usize];
-        if c1 != c2 {
-            return c1 > c2;
-        }
-        s1 = quadrant[i1 as usize];
-        s2 = quadrant[i2 as usize];
-        if s1 != s2 {
-            return s1 > s2;
-        }
-        i1 = i1.wrapping_add(1);
-        i2 = i2.wrapping_add(1);
+
         if i1 >= nblock {
             i1 = i1.wrapping_sub(nblock);
         }

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -390,12 +390,6 @@ fn mainGtU(
     nblock: u32,
     budget: &mut i32,
 ) -> bool {
-    let mut k: i32;
-    let mut c1: u8;
-    let mut c2: u8;
-    let mut s1: u16;
-    let mut s2: u16;
-
     debug_assert_ne!(i1, i2, "mainGtU");
 
     let chunk1 = &block[i1 as usize..][..12];
@@ -414,20 +408,23 @@ fn mainGtU(
     i2 += 12;
 
     for _ in 0..nblock.div_ceil(8) {
-        for _ in 0..8 {
-            c1 = block[i1 as usize];
-            c2 = block[i2 as usize];
+        let b1 = &block[i1 as usize..][..8];
+        let b2 = &block[i2 as usize..][..8];
+
+        let q1 = &quadrant[i1 as usize..][..8];
+        let q2 = &quadrant[i2 as usize..][..8];
+
+        for (((c1, c2), s1), s2) in b1.iter().zip(b2).zip(q1).zip(q2) {
             if c1 != c2 {
                 return c1 > c2;
             }
-            s1 = quadrant[i1 as usize];
-            s2 = quadrant[i2 as usize];
             if s1 != s2 {
                 return s1 > s2;
             }
-            i1 = i1.wrapping_add(1);
-            i2 = i2.wrapping_add(1);
         }
+
+        i1 += 8;
+        i2 += 8;
 
         if i1 >= nblock {
             i1 = i1.wrapping_sub(nblock);

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -414,12 +414,14 @@ fn mainGtU(
         let q1 = &quadrant[i1 as usize..][..8];
         let q2 = &quadrant[i2 as usize..][..8];
 
-        for (((c1, c2), s1), s2) in b1.iter().zip(b2).zip(q1).zip(q2) {
-            if c1 != c2 {
-                return c1 > c2;
-            }
-            if s1 != s2 {
-                return s1 > s2;
+        if b1 != b2 || q1 != q2 {
+            for (((c1, c2), s1), s2) in b1.iter().zip(b2).zip(q1).zip(q2) {
+                if c1 != c2 {
+                    return c1 > c2;
+                }
+                if s1 != s2 {
+                    return s1 > s2;
+                }
             }
         }
 
@@ -432,6 +434,7 @@ fn mainGtU(
         if i2 >= nblock {
             i2 = i2.wrapping_sub(nblock);
         }
+
         *budget -= 1;
     }
 

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -413,8 +413,7 @@ fn mainGtU(
     i1 += 12;
     i2 += 12;
 
-    k = nblock.wrapping_add(8 as c_int as c_uint) as i32;
-    loop {
+    for _ in 0..nblock.div_ceil(8) {
         for _ in 0..8 {
             c1 = block[i1 as usize];
             c2 = block[i2 as usize];
@@ -436,13 +435,12 @@ fn mainGtU(
         if i2 >= nblock {
             i2 = i2.wrapping_sub(nblock);
         }
-        k -= 8 as c_int;
         *budget -= 1;
-        if k < 0 as c_int {
-            break false;
-        }
     }
+
+    false
 }
+
 static INCS: [i32; 14] = [
     1 as c_int,
     4 as c_int,

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -398,90 +398,21 @@ fn mainGtU(
 
     debug_assert_ne!(i1, i2, "mainGtU");
 
-    c1 = block[i1 as usize];
-    c2 = block[i2 as usize];
-    if c1 != c2 {
-        return c1 > c2;
+    let chunk1 = &block[i1 as usize..][..12];
+    let chunk2 = &block[i2 as usize..][..12];
+
+    for (c1, c2) in chunk1.chunks_exact(4).zip(chunk2.chunks_exact(4)) {
+        let c1 = u32::from_be_bytes(c1[..4].try_into().unwrap());
+        let c2 = u32::from_be_bytes(c2[..4].try_into().unwrap());
+
+        if c1 != c2 {
+            return c1 > c2;
+        }
     }
-    i1 = i1.wrapping_add(1);
-    i2 = i2.wrapping_add(1);
-    c1 = block[i1 as usize];
-    c2 = block[i2 as usize];
-    if c1 != c2 {
-        return c1 > c2;
-    }
-    i1 = i1.wrapping_add(1);
-    i2 = i2.wrapping_add(1);
-    c1 = block[i1 as usize];
-    c2 = block[i2 as usize];
-    if c1 != c2 {
-        return c1 > c2;
-    }
-    i1 = i1.wrapping_add(1);
-    i2 = i2.wrapping_add(1);
-    c1 = block[i1 as usize];
-    c2 = block[i2 as usize];
-    if c1 != c2 {
-        return c1 > c2;
-    }
-    i1 = i1.wrapping_add(1);
-    i2 = i2.wrapping_add(1);
-    c1 = block[i1 as usize];
-    c2 = block[i2 as usize];
-    if c1 != c2 {
-        return c1 > c2;
-    }
-    i1 = i1.wrapping_add(1);
-    i2 = i2.wrapping_add(1);
-    c1 = block[i1 as usize];
-    c2 = block[i2 as usize];
-    if c1 != c2 {
-        return c1 > c2;
-    }
-    i1 = i1.wrapping_add(1);
-    i2 = i2.wrapping_add(1);
-    c1 = block[i1 as usize];
-    c2 = block[i2 as usize];
-    if c1 != c2 {
-        return c1 > c2;
-    }
-    i1 = i1.wrapping_add(1);
-    i2 = i2.wrapping_add(1);
-    c1 = block[i1 as usize];
-    c2 = block[i2 as usize];
-    if c1 != c2 {
-        return c1 > c2;
-    }
-    i1 = i1.wrapping_add(1);
-    i2 = i2.wrapping_add(1);
-    c1 = block[i1 as usize];
-    c2 = block[i2 as usize];
-    if c1 != c2 {
-        return c1 > c2;
-    }
-    i1 = i1.wrapping_add(1);
-    i2 = i2.wrapping_add(1);
-    c1 = block[i1 as usize];
-    c2 = block[i2 as usize];
-    if c1 != c2 {
-        return c1 > c2;
-    }
-    i1 = i1.wrapping_add(1);
-    i2 = i2.wrapping_add(1);
-    c1 = block[i1 as usize];
-    c2 = block[i2 as usize];
-    if c1 != c2 {
-        return c1 > c2;
-    }
-    i1 = i1.wrapping_add(1);
-    i2 = i2.wrapping_add(1);
-    c1 = block[i1 as usize];
-    c2 = block[i2 as usize];
-    if c1 != c2 {
-        return c1 > c2;
-    }
-    i1 = i1.wrapping_add(1);
-    i2 = i2.wrapping_add(1);
+
+    i1 += 12;
+    i2 += 12;
+
     k = nblock.wrapping_add(8 as c_int as c_uint) as i32;
     loop {
         c1 = block[i1 as usize];


### PR DESCRIPTION
Rewrite code so that it is easier to vectorize. With these changes we now beat stock bzip2 handsomely on the compression benchmarks that I looked at. e.g

```
Benchmark 1 (6 runs): target/release/examples/compress c 9 /home/folkertdev/rust/zlib-rs/silesia-small.tar
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           923ms ± 9.69ms     918ms …  943ms          0 ( 0%)        0%
  peak_rss           29.5MB ± 98.7KB    29.4MB … 29.6MB          0 ( 0%)        0%
  cpu_cycles         4.16G  ± 33.1M     4.14G  … 4.23G           0 ( 0%)        0%
  instructions       7.94G  ±  310      7.94G  … 7.94G           0 ( 0%)        0%
  cache_references    150M  ±  504K      150M  …  151M           0 ( 0%)        0%
  cache_misses       37.8M  ±  445K     37.1M  … 38.4M           0 ( 0%)        0%
  branch_misses      61.2M  ± 46.2K     61.2M  … 61.3M           0 ( 0%)        0%
Benchmark 2 (7 runs): target/release/examples/compress rs 9 /home/folkertdev/rust/zlib-rs/silesia-small.tar
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           818ms ± 3.00ms     814ms …  823ms          0 ( 0%)        ⚡- 11.5% ±  0.9%
  peak_rss           29.6MB ± 49.5KB    29.5MB … 29.6MB          1 (14%)          +  0.3% ±  0.3%
  cpu_cycles         3.67G  ± 10.8M     3.66G  … 3.69G           0 ( 0%)        ⚡- 11.8% ±  0.7%
  instructions       9.27G  ± 40.5K     9.27G  … 9.27G           0 ( 0%)        💩+ 16.7% ±  0.0%
  cache_references    151M  ±  556K      150M  …  152M           0 ( 0%)          +  0.5% ±  0.4%
  cache_misses       38.4M  ±  302K     38.0M  … 38.9M           0 ( 0%)          +  1.6% ±  1.2%
  branch_misses      52.3M  ± 21.3K     52.3M  … 52.4M           0 ( 0%)        ⚡- 14.5% ±  0.1%
```