### PR TITLE
`decompress.rs`: faster input reading

### DIFF
--- a/libbz2-rs-sys/src/bzlib.rs
+++ b/libbz2-rs-sys/src/bzlib.rs
@@ -259,7 +259,7 @@ mod stream {
             }
 
             // of course this uses big endian values
-            let read = unsafe { self.next_in.cast::<u64>().read_unaligned().to_be() };
+            let read = u64::from_be_bytes(unsafe { self.next_in.cast::<[u8; 8]>().read() });
 
             // because of the endianness, we can only shift in whole bytes.
             // this calculates the number of available bits, rounded down to the nearest multiple
@@ -279,6 +279,9 @@ mod stream {
             Some((bit_buffer, bits_used + increment_bits))
         }
 
+        /// Read exactly 1 byte into the buffer
+        ///
+        /// The caller is responsible for updating `self.total_in`!
         #[must_use]
         #[inline(always)]
         pub(crate) fn pull_u8(
@@ -292,7 +295,7 @@ mod stream {
 
             let read = unsafe { *(self.next_in as *mut u8) };
             bit_buffer <<= 8;
-            bit_buffer |= read as u64;
+            bit_buffer |= u64::from(read);
 
             self.next_in = unsafe { (self.next_in).offset(1) };
             self.avail_in -= 1;

--- a/libbz2-rs-sys/src/bzlib.rs
+++ b/libbz2-rs-sys/src/bzlib.rs
@@ -254,6 +254,9 @@ mod stream {
             mut bit_buffer: u64,
             bits_used: i32,
         ) -> Option<(u64, i32)> {
+            // we should only ask for more input if there are at least 8 free bits
+            debug_assert!(bits_used <= 56);
+
             if self.avail_in < 8 {
                 return None;
             }
@@ -289,6 +292,9 @@ mod stream {
             mut bit_buffer: u64,
             bits_used: i32,
         ) -> Option<(u64, i32)> {
+            // we should only ask for more input if there are at least 8 free bits
+            debug_assert!(bits_used <= 56);
+
             if self.avail_in == 0 || bits_used > 56 {
                 return None;
             }

--- a/libbz2-rs-sys/src/bzlib.rs
+++ b/libbz2-rs-sys/src/bzlib.rs
@@ -245,6 +245,21 @@ mod stream {
         }
 
         #[must_use]
+        #[inline(always)]
+        pub(crate) fn read_byte_fast(&mut self) -> Option<u8> {
+            if self.avail_in == 0 {
+                return None;
+            }
+            let b = unsafe { *(self.next_in as *mut u8) };
+            self.next_in = unsafe { (self.next_in).offset(1) };
+            self.avail_in -= 1;
+
+            // skips updating `self.total_in`: the caller is responsible for keeping it updated
+
+            Some(b)
+        }
+
+        #[must_use]
         pub(crate) fn read_byte(&mut self) -> Option<u8> {
             if self.avail_in == 0 {
                 return None;

--- a/libbz2-rs-sys/src/bzlib.rs
+++ b/libbz2-rs-sys/src/bzlib.rs
@@ -244,26 +244,29 @@ mod stream {
             unsafe { Allocator::from_bz_stream(self) }
         }
 
+        /// Read up to 7 bytes into the bit buffer.
+        ///
+        /// The caller is responsible for updating `self.total_in`!
         #[must_use]
         #[inline(always)]
-        pub(crate) fn pull_u32(
+        pub(crate) fn pull_u64(
             &mut self,
             mut bit_buffer: u64,
             bits_used: i32,
         ) -> Option<(u64, i32)> {
-            if self.avail_in < 4 {
+            if self.avail_in < 8 {
                 return None;
             }
 
             // of course this uses big endian values
-            let read = unsafe { self.next_in.cast::<u32>().read_unaligned().to_be() };
+            let read = unsafe { self.next_in.cast::<u64>().read_unaligned().to_be() };
 
             // because of the endianness, we can only shift in whole bytes.
-            let increment_bytes = (31 - bits_used) / 8;
+            let increment_bytes = (63 - bits_used) / 8;
             let increment_bits = 8 * increment_bytes;
 
             bit_buffer <<= increment_bits;
-            bit_buffer |= (read >> (32 - increment_bits)) as u64;
+            bit_buffer |= (read >> (64 - increment_bits)) as u64;
 
             self.next_in = unsafe { (self.next_in).add(increment_bytes as usize) };
             self.avail_in -= increment_bytes as u32;

--- a/libbz2-rs-sys/src/bzlib.rs
+++ b/libbz2-rs-sys/src/bzlib.rs
@@ -248,9 +248,9 @@ mod stream {
         #[inline(always)]
         pub(crate) fn pull_u32(
             &mut self,
-            mut bit_buffer: u32,
+            mut bit_buffer: u64,
             bits_used: i32,
-        ) -> Option<(u32, i32)> {
+        ) -> Option<(u64, i32)> {
             if self.avail_in < 4 {
                 return None;
             }
@@ -263,7 +263,7 @@ mod stream {
             let increment_bits = 8 * increment_bytes;
 
             bit_buffer <<= increment_bits;
-            bit_buffer |= read >> (32 - increment_bits);
+            bit_buffer |= (read >> (32 - increment_bits)) as u64;
 
             self.next_in = unsafe { (self.next_in).add(increment_bytes as usize) };
             self.avail_in -= increment_bytes as u32;
@@ -577,7 +577,7 @@ pub(crate) struct DState {
     pub k0: u8,
     pub rNToGo: i32,
     pub rTPos: i32,
-    pub bsBuff: u32,
+    pub bsBuff: u64,
     pub bsLive: i32,
     pub smallDecompress: DecompressMode,
     pub currBlockNo: i32,

--- a/libbz2-rs-sys/src/decompress.rs
+++ b/libbz2-rs-sys/src/decompress.rs
@@ -187,7 +187,10 @@ pub(crate) fn decompress(
                         break v;
                     }
 
-                    if let Some(next_byte) = strm.read_byte_fast() {
+                    if let Some((bit_buffer, bits_used)) = strm.pull_u32($s.bsBuff, $s.bsLive) {
+                        $s.bsBuff = bit_buffer;
+                        $s.bsLive = bits_used;
+                    } else if let Some(next_byte) = strm.read_byte_fast() {
                         $s.bsBuff = $s.bsBuff << 8 | next_byte as u32;
                         $s.bsLive += 8;
                     } else {

--- a/libbz2-rs-sys/src/decompress.rs
+++ b/libbz2-rs-sys/src/decompress.rs
@@ -187,7 +187,7 @@ pub(crate) fn decompress(
                         break v as u32;
                     }
 
-                    if let Some((bit_buffer, bits_used)) = strm.pull_u32($s.bsBuff, $s.bsLive) {
+                    if let Some((bit_buffer, bits_used)) = strm.pull_u64($s.bsBuff, $s.bsLive) {
                         $s.bsBuff = bit_buffer;
                         $s.bsLive = bits_used;
                     } else if let Some(next_byte) = strm.read_byte_fast() {

--- a/libbz2-rs-sys/src/decompress.rs
+++ b/libbz2-rs-sys/src/decompress.rs
@@ -182,16 +182,16 @@ pub(crate) fn decompress(
             ($strm:expr, $s:expr, $nnn:expr) => {
                 loop {
                     if $s.bsLive >= $nnn {
-                        let v: u32 = ($s.bsBuff >> ($s.bsLive - $nnn)) & ((1 << $nnn) - 1);
+                        let v: u64 = ($s.bsBuff >> ($s.bsLive - $nnn)) & ((1 << $nnn) - 1);
                         $s.bsLive -= $nnn;
-                        break v;
+                        break v as u32;
                     }
 
                     if let Some((bit_buffer, bits_used)) = strm.pull_u32($s.bsBuff, $s.bsLive) {
                         $s.bsBuff = bit_buffer;
                         $s.bsLive = bits_used;
                     } else if let Some(next_byte) = strm.read_byte_fast() {
-                        $s.bsBuff = $s.bsBuff << 8 | next_byte as u32;
+                        $s.bsBuff = $s.bsBuff << 8 | next_byte as u64;
                         $s.bsLive += 8;
                     } else {
                         break 'save_state_and_return ReturnCode::BZ_OK;

--- a/libbz2-rs-sys/src/decompress.rs
+++ b/libbz2-rs-sys/src/decompress.rs
@@ -184,15 +184,16 @@ pub(crate) fn decompress(
                     if $s.bsLive >= $nnn {
                         let v: u64 = ($s.bsBuff >> ($s.bsLive - $nnn)) & ((1 << $nnn) - 1);
                         $s.bsLive -= $nnn;
-                        break v as u32;
+                        break v;
                     }
 
                     if let Some((bit_buffer, bits_used)) = strm.pull_u64($s.bsBuff, $s.bsLive) {
                         $s.bsBuff = bit_buffer;
                         $s.bsLive = bits_used;
-                    } else if let Some(next_byte) = strm.read_byte_fast() {
-                        $s.bsBuff = $s.bsBuff << 8 | next_byte as u64;
-                        $s.bsLive += 8;
+                    } else if let Some((bit_buffer, bits_used)) = strm.pull_u8($s.bsBuff, $s.bsLive)
+                    {
+                        $s.bsBuff = bit_buffer;
+                        $s.bsLive = bits_used;
                     } else {
                         break 'save_state_and_return ReturnCode::BZ_OK;
                     }


### PR DESCRIPTION
attempt to read up to 7 bytes at once, cutting down on the total number of reads. This has some nice performance benefits.