### PR TITLE
Cleanup `blocksort` more

### DIFF
--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -595,28 +595,24 @@ fn mainQSort3(
     let mut n: i32;
     let mut m: i32;
     let mut med: i32;
-    let mut sp: i32;
     let mut lo: i32;
     let mut hi: i32;
     let mut d: i32;
-    let mut stackLo: [i32; 100] = [0; 100];
-    let mut stackHi: [i32; 100] = [0; 100];
-    let mut stackD: [i32; 100] = [0; 100];
+
+    let mut stack = [(0i32, 0i32, 0i32); 100];
+
     let mut nextLo: [i32; 3] = [0; 3];
     let mut nextHi: [i32; 3] = [0; 3];
     let mut nextD: [i32; 3] = [0; 3];
-    sp = 0;
-    stackLo[sp as usize] = loSt;
-    stackHi[sp as usize] = hiSt;
-    stackD[sp as usize] = dSt;
-    sp += 1;
+
+    stack[0] = (loSt, hiSt, dSt);
+
+    let mut sp = 1;
     while sp > 0 {
-        assert_h!(sp < MAIN_QSORT_STACK_SIZE - 2, 1001);
+        assert_h!(sp < MAIN_QSORT_STACK_SIZE as usize - 2, 1001);
 
         sp -= 1;
-        lo = stackLo[sp as usize];
-        hi = stackHi[sp as usize];
-        d = stackD[sp as usize];
+        (lo, hi, d) = stack[sp];
         if hi - lo < MAIN_QSORT_SMALL_THRESH || d > MAIN_QSORT_DEPTH_THRESH {
             mainSimpleSort(ptr, block, quadrant, nblock, lo, hi, d, budget);
             if *budget < 0 {
@@ -680,9 +676,7 @@ fn mainQSort3(
                 unHi -= 1;
             }
             if gtHi < ltLo {
-                stackLo[sp as usize] = lo;
-                stackHi[sp as usize] = hi;
-                stackD[sp as usize] = d + 1;
+                stack[sp] = (lo, hi, d + 1);
                 sp += 1;
             } else {
                 n = if ltLo - lo < unLo - ltLo {
@@ -764,17 +758,11 @@ fn mainQSort3(
                     nextD[0] = nextD[1];
                     nextD[1] = tz_1;
                 }
-                stackLo[sp as usize] = nextLo[0];
-                stackHi[sp as usize] = nextHi[0];
-                stackD[sp as usize] = nextD[0];
+                stack[sp] = (nextLo[0], nextHi[0], nextD[0]);
                 sp += 1;
-                stackLo[sp as usize] = nextLo[1];
-                stackHi[sp as usize] = nextHi[1];
-                stackD[sp as usize] = nextD[1];
+                stack[sp] = (nextLo[1], nextHi[1], nextD[1]);
                 sp += 1;
-                stackLo[sp as usize] = nextLo[2];
-                stackHi[sp as usize] = nextHi[2];
-                stackD[sp as usize] = nextD[2];
+                stack[sp] = (nextLo[2], nextHi[2], nextD[2]);
                 sp += 1;
             }
         }

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -600,7 +600,6 @@ fn mainQSort3(
     let mut d: i32;
 
     let mut stack = [(0i32, 0i32, 0i32); 100];
-    let mut next: [(i32, i32, i32); 3];
 
     stack[0] = (loSt, hiSt, dSt);
 
@@ -683,7 +682,7 @@ fn mainQSort3(
                 n = lo + unLo - ltLo - 1;
                 m = hi - (gtHi - unHi) + 1;
 
-                next = [(lo, n, d), (m, hi, d), (n + 1, m - 1, d + 1)];
+                let mut next = [(lo, n, d), (m, hi, d), (n + 1, m - 1, d + 1)];
 
                 if next[0].1 - next[0].0 < next[1].1 - next[1].0 {
                     next.swap(0, 1);

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -442,21 +442,9 @@ fn mainGtU(
 }
 
 static INCS: [i32; 14] = [
-    1 as c_int,
-    4 as c_int,
-    13 as c_int,
-    40 as c_int,
-    121 as c_int,
-    364 as c_int,
-    1093 as c_int,
-    3280 as c_int,
-    9841 as c_int,
-    29524 as c_int,
-    88573 as c_int,
-    265720 as c_int,
-    797161 as c_int,
-    2391484 as c_int,
+    1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573, 265720, 797161, 2391484,
 ];
+
 fn mainSimpleSort(
     ptr: &mut [u32],
     block: &[u8],
@@ -469,21 +457,15 @@ fn mainSimpleSort(
 ) {
     let mut i: i32;
     let mut j: i32;
-    let mut h: i32;
-    let mut hp: i32;
     let mut v: u32;
 
-    let bigN = hi - lo + 1 as c_int;
-    if bigN < 2 as c_int {
+    let bigN = hi - lo + 1;
+
+    let Some(index) = INCS.iter().position(|&e| e >= bigN) else {
         return;
-    }
-    hp = 0 as c_int;
-    while INCS[hp as usize] < bigN {
-        hp += 1;
-    }
-    hp -= 1;
-    while hp >= 0 as c_int {
-        h = INCS[hp as usize];
+    };
+
+    for &h in INCS[..index].iter().rev() {
         i = lo + h;
         loop {
             if i > hi {
@@ -553,7 +535,6 @@ fn mainSimpleSort(
                 return;
             }
         }
-        hp -= 1;
     }
 }
 

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -600,10 +600,7 @@ fn mainQSort3(
     let mut d: i32;
 
     let mut stack = [(0i32, 0i32, 0i32); 100];
-
-    let mut nextLo: [i32; 3] = [0; 3];
-    let mut nextHi: [i32; 3] = [0; 3];
-    let mut nextD: [i32; 3] = [0; 3];
+    let mut next: [(i32, i32, i32); 3];
 
     stack[0] = (loSt, hiSt, dSt);
 
@@ -713,57 +710,23 @@ fn mainQSort3(
                 }
                 n = lo + unLo - ltLo - 1;
                 m = hi - (gtHi - unHi) + 1;
-                nextLo[0] = lo;
-                nextHi[0] = n;
-                nextD[0] = d;
-                nextLo[1] = m;
-                nextHi[1] = hi;
-                nextD[1] = d;
-                nextLo[2] = n + 1;
-                nextHi[2] = m - 1;
-                nextD[2] = d + 1;
-                if nextHi[0] - nextLo[0] < nextHi[1] - nextLo[1] {
-                    let mut tz: i32;
-                    tz = nextLo[0];
-                    nextLo[0] = nextLo[1];
-                    nextLo[1] = tz;
-                    tz = nextHi[0];
-                    nextHi[0] = nextHi[1];
-                    nextHi[1] = tz;
-                    tz = nextD[0];
-                    nextD[0] = nextD[1];
-                    nextD[1] = tz;
+
+                next = [(lo, n, d), (m, hi, d), (n + 1, m - 1, d + 1)];
+
+                if next[0].1 - next[0].0 < next[1].1 - next[1].0 {
+                    next.swap(0, 1);
                 }
-                if nextHi[1] - nextLo[1] < nextHi[2] - nextLo[2] {
-                    let mut tz_0: i32;
-                    tz_0 = nextLo[1];
-                    nextLo[1] = nextLo[2];
-                    nextLo[2] = tz_0;
-                    tz_0 = nextHi[1];
-                    nextHi[1] = nextHi[2];
-                    nextHi[2] = tz_0;
-                    tz_0 = nextD[1];
-                    nextD[1] = nextD[2];
-                    nextD[2] = tz_0;
+
+                if next[1].1 - next[1].0 < next[2].1 - next[2].0 {
+                    next.swap(1, 2);
                 }
-                if nextHi[0] - nextLo[0] < nextHi[1] - nextLo[1] {
-                    let mut tz_1: i32;
-                    tz_1 = nextLo[0];
-                    nextLo[0] = nextLo[1];
-                    nextLo[1] = tz_1;
-                    tz_1 = nextHi[0];
-                    nextHi[0] = nextHi[1];
-                    nextHi[1] = tz_1;
-                    tz_1 = nextD[0];
-                    nextD[0] = nextD[1];
-                    nextD[1] = tz_1;
+
+                if next[0].1 - next[0].0 < next[1].1 - next[1].0 {
+                    next.swap(0, 1);
                 }
-                stack[sp] = (nextLo[0], nextHi[0], nextD[0]);
-                sp += 1;
-                stack[sp] = (nextLo[1], nextHi[1], nextD[1]);
-                sp += 1;
-                stack[sp] = (nextLo[2], nextHi[2], nextD[2]);
-                sp += 1;
+
+                stack[sp..][..next.len()].copy_from_slice(&next);
+                sp += next.len();
             }
         }
     }

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -662,11 +662,7 @@ fn mainQSort3(
                 stack[sp] = (lo, hi, d + 1);
                 sp += 1;
             } else {
-                n = if ltLo - lo < unLo - ltLo {
-                    ltLo - lo
-                } else {
-                    unLo - ltLo
-                };
+                n = Ord::min(ltLo - lo, unLo - ltLo);
                 let mut yyp1: i32 = lo;
                 let mut yyp2: i32 = unLo - n;
                 let mut yyn: i32 = n;
@@ -676,11 +672,8 @@ fn mainQSort3(
                     yyp2 += 1;
                     yyn -= 1;
                 }
-                m = if hi - gtHi < gtHi - unHi {
-                    hi - gtHi
-                } else {
-                    gtHi - unHi
-                };
+
+                m = Ord::min(hi - gtHi, gtHi - unHi);
                 let mut yyp1_0: i32 = unLo;
                 let mut yyp2_0: i32 = hi - m + 1;
                 let mut yyn_0: i32 = m;
@@ -690,6 +683,7 @@ fn mainQSort3(
                     yyp2_0 += 1;
                     yyn_0 -= 1;
                 }
+
                 n = lo + unLo - ltLo - 1;
                 m = hi - (gtHi - unHi) + 1;
 

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -488,19 +488,19 @@ fn mainSimpleSort(
 }
 
 #[inline]
-fn mmed3(mut a: u8, mut b: u8, c: u8) -> u8 {
-    let t: u8;
+fn median_of_3(mut a: u8, mut b: u8, mut c: u8) -> u8 {
     if a > b {
-        t = a;
-        a = b;
-        b = t;
+        (a, b) = (b, a);
+    }
+    if a > c {
+        (_, c) = (c, a);
     }
     if b > c {
-        b = c;
-        if a > b {
-            b = a;
-        }
+        (b, _) = (c, b);
     }
+
+    debug_assert!(a <= b && b <= c);
+
     b
 }
 
@@ -545,7 +545,7 @@ fn mainQSort3(
                 return;
             }
         } else {
-            med = mmed3(
+            med = median_of_3(
                 block[(ptr[lo as usize]).wrapping_add(d as c_uint) as usize],
                 block[(ptr[hi as usize]).wrapping_add(d as c_uint) as usize],
                 block[((ptr[((lo + hi) >> 1) as usize]).wrapping_add(d as c_uint) as isize)

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -455,10 +455,6 @@ fn mainSimpleSort(
     d: i32,
     budget: &mut i32,
 ) {
-    let mut i: i32;
-    let mut j: i32;
-    let mut v: u32;
-
     let bigN = hi - lo + 1;
 
     let Some(index) = INCS.iter().position(|&e| e >= bigN) else {
@@ -466,10 +462,9 @@ fn mainSimpleSort(
     };
 
     for &h in INCS[..index].iter().rev() {
-        i = lo + h;
-        while i <= hi {
-            v = ptr[i as usize];
-            j = i;
+        for i in lo + h..=hi {
+            let v = ptr[i as usize];
+            let mut j = i;
             while mainGtU(
                 (ptr[(j - h) as usize]).wrapping_add(d as u32),
                 v.wrapping_add(d as u32),
@@ -480,12 +475,11 @@ fn mainSimpleSort(
             ) {
                 ptr[j as usize] = ptr[(j - h) as usize];
                 j -= h;
-                if j <= lo + h - 1 {
+                if j < lo + h {
                     break;
                 }
             }
             ptr[j as usize] = v;
-            i += 1;
             if *budget < 0 {
                 return;
             }

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -627,10 +627,7 @@ fn mainQSort3(
             gtHi = hi;
             unHi = gtHi;
             loop {
-                loop {
-                    if unLo > unHi {
-                        break;
-                    }
+                while unLo <= unHi {
                     n = block[(ptr[unLo as usize]).wrapping_add(d as c_uint) as usize] as i32 - med;
                     match n.cmp(&0) {
                         Ordering::Greater => break,
@@ -644,10 +641,7 @@ fn mainQSort3(
                         Ordering::Less => unLo += 1,
                     }
                 }
-                loop {
-                    if unLo > unHi {
-                        break;
-                    }
+                while unLo <= unHi {
                     n = block[(ptr[unHi as usize]).wrapping_add(d as c_uint) as usize] as i32 - med;
                     match n.cmp(&0) {
                         Ordering::Less => break,

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -665,23 +665,19 @@ fn mainQSort3(
                 n = Ord::min(ltLo - lo, unLo - ltLo);
                 let mut yyp1: i32 = lo;
                 let mut yyp2: i32 = unLo - n;
-                let mut yyn: i32 = n;
-                while yyn > 0 {
+                for _ in 0..n {
                     ptr.swap(yyp1 as usize, yyp2 as usize);
                     yyp1 += 1;
                     yyp2 += 1;
-                    yyn -= 1;
                 }
 
                 m = Ord::min(hi - gtHi, gtHi - unHi);
                 let mut yyp1_0: i32 = unLo;
                 let mut yyp2_0: i32 = hi - m + 1;
-                let mut yyn_0: i32 = m;
-                while yyn_0 > 0 {
+                for _ in 0..m {
                     ptr.swap(yyp1_0 as usize, yyp2_0 as usize);
                     yyp1_0 += 1;
                     yyp2_0 += 1;
-                    yyn_0 -= 1;
                 }
 
                 n = lo + unLo - ltLo - 1;

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -386,7 +386,7 @@ fn mainGtU(
     mut i1: u32,
     mut i2: u32,
     block: &[u8],
-    quadrant: &mut [u16],
+    quadrant: &[u16],
     nblock: u32,
     budget: &mut i32,
 ) -> bool {
@@ -460,7 +460,7 @@ static INCS: [i32; 14] = [
 fn mainSimpleSort(
     ptr: &mut [u32],
     block: &[u8],
-    quadrant: &mut [u16],
+    quadrant: &[u16],
     nblock: i32,
     lo: i32,
     hi: i32,
@@ -581,7 +581,7 @@ const MAIN_QSORT_STACK_SIZE: i32 = 100;
 fn mainQSort3(
     ptr: &mut [u32],
     block: &[u8],
-    quadrant: &mut [u16],
+    quadrant: &[u16],
     nblock: i32,
     loSt: i32,
     hiSt: i32,

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -605,12 +605,12 @@ fn mainQSort3(
     let mut nextLo: [i32; 3] = [0; 3];
     let mut nextHi: [i32; 3] = [0; 3];
     let mut nextD: [i32; 3] = [0; 3];
-    sp = 0 as c_int;
+    sp = 0;
     stackLo[sp as usize] = loSt;
     stackHi[sp as usize] = hiSt;
     stackD[sp as usize] = dSt;
     sp += 1;
-    while sp > 0 as c_int {
+    while sp > 0 {
         assert_h!(sp < MAIN_QSORT_STACK_SIZE - 2, 1001);
 
         sp -= 1;
@@ -619,14 +619,14 @@ fn mainQSort3(
         d = stackD[sp as usize];
         if hi - lo < MAIN_QSORT_SMALL_THRESH || d > MAIN_QSORT_DEPTH_THRESH {
             mainSimpleSort(ptr, block, quadrant, nblock, lo, hi, d, budget);
-            if *budget < 0 as c_int {
+            if *budget < 0 {
                 return;
             }
         } else {
             med = mmed3(
                 block[(ptr[lo as usize]).wrapping_add(d as c_uint) as usize],
                 block[(ptr[hi as usize]).wrapping_add(d as c_uint) as usize],
-                block[((ptr[((lo + hi) >> 1 as c_int) as usize]).wrapping_add(d as c_uint) as isize)
+                block[((ptr[((lo + hi) >> 1) as usize]).wrapping_add(d as c_uint) as isize)
                     as usize],
             ) as i32;
             ltLo = lo;
@@ -639,14 +639,14 @@ fn mainQSort3(
                         break;
                     }
                     n = block[(ptr[unLo as usize]).wrapping_add(d as c_uint) as usize] as i32 - med;
-                    if n == 0 as c_int {
+                    if n == 0 {
                         let zztmp: i32 = ptr[unLo as usize] as i32;
                         ptr[unLo as usize] = ptr[ltLo as usize];
                         ptr[ltLo as usize] = zztmp as u32;
                         ltLo += 1;
                         unLo += 1;
                     } else {
-                        if n > 0 as c_int {
+                        if n > 0 {
                             break;
                         }
                         unLo += 1;
@@ -657,14 +657,14 @@ fn mainQSort3(
                         break;
                     }
                     n = block[(ptr[unHi as usize]).wrapping_add(d as c_uint) as usize] as i32 - med;
-                    if n == 0 as c_int {
+                    if n == 0 {
                         let zztmp_0: i32 = ptr[unHi as usize] as i32;
                         ptr[unHi as usize] = ptr[gtHi as usize];
                         ptr[gtHi as usize] = zztmp_0 as u32;
                         gtHi -= 1;
                         unHi -= 1;
                     } else {
-                        if n < 0 as c_int {
+                        if n < 0 {
                             break;
                         }
                         unHi -= 1;
@@ -682,7 +682,7 @@ fn mainQSort3(
             if gtHi < ltLo {
                 stackLo[sp as usize] = lo;
                 stackHi[sp as usize] = hi;
-                stackD[sp as usize] = d + 1 as c_int;
+                stackD[sp as usize] = d + 1;
                 sp += 1;
             } else {
                 n = if ltLo - lo < unLo - ltLo {
@@ -693,7 +693,7 @@ fn mainQSort3(
                 let mut yyp1: i32 = lo;
                 let mut yyp2: i32 = unLo - n;
                 let mut yyn: i32 = n;
-                while yyn > 0 as c_int {
+                while yyn > 0 {
                     let zztmp_2: i32 = ptr[yyp1 as usize] as i32;
                     ptr[yyp1 as usize] = ptr[yyp2 as usize];
                     ptr[yyp2 as usize] = zztmp_2 as u32;
@@ -707,9 +707,9 @@ fn mainQSort3(
                     gtHi - unHi
                 };
                 let mut yyp1_0: i32 = unLo;
-                let mut yyp2_0: i32 = hi - m + 1 as c_int;
+                let mut yyp2_0: i32 = hi - m + 1;
                 let mut yyn_0: i32 = m;
-                while yyn_0 > 0 as c_int {
+                while yyn_0 > 0 {
                     let zztmp_3: i32 = ptr[yyp1_0 as usize] as i32;
                     ptr[yyp1_0 as usize] = ptr[yyp2_0 as usize];
                     ptr[yyp2_0 as usize] = zztmp_3 as u32;
@@ -717,70 +717,64 @@ fn mainQSort3(
                     yyp2_0 += 1;
                     yyn_0 -= 1;
                 }
-                n = lo + unLo - ltLo - 1 as c_int;
-                m = hi - (gtHi - unHi) + 1 as c_int;
-                nextLo[0 as c_int as usize] = lo;
-                nextHi[0 as c_int as usize] = n;
-                nextD[0 as c_int as usize] = d;
-                nextLo[1 as c_int as usize] = m;
-                nextHi[1 as c_int as usize] = hi;
-                nextD[1 as c_int as usize] = d;
-                nextLo[2 as c_int as usize] = n + 1 as c_int;
-                nextHi[2 as c_int as usize] = m - 1 as c_int;
-                nextD[2 as c_int as usize] = d + 1 as c_int;
-                if nextHi[0 as c_int as usize] - nextLo[0 as c_int as usize]
-                    < nextHi[1 as c_int as usize] - nextLo[1 as c_int as usize]
-                {
+                n = lo + unLo - ltLo - 1;
+                m = hi - (gtHi - unHi) + 1;
+                nextLo[0] = lo;
+                nextHi[0] = n;
+                nextD[0] = d;
+                nextLo[1] = m;
+                nextHi[1] = hi;
+                nextD[1] = d;
+                nextLo[2] = n + 1;
+                nextHi[2] = m - 1;
+                nextD[2] = d + 1;
+                if nextHi[0] - nextLo[0] < nextHi[1] - nextLo[1] {
                     let mut tz: i32;
-                    tz = nextLo[0 as c_int as usize];
-                    nextLo[0 as c_int as usize] = nextLo[1 as c_int as usize];
-                    nextLo[1 as c_int as usize] = tz;
-                    tz = nextHi[0 as c_int as usize];
-                    nextHi[0 as c_int as usize] = nextHi[1 as c_int as usize];
-                    nextHi[1 as c_int as usize] = tz;
-                    tz = nextD[0 as c_int as usize];
-                    nextD[0 as c_int as usize] = nextD[1 as c_int as usize];
-                    nextD[1 as c_int as usize] = tz;
+                    tz = nextLo[0];
+                    nextLo[0] = nextLo[1];
+                    nextLo[1] = tz;
+                    tz = nextHi[0];
+                    nextHi[0] = nextHi[1];
+                    nextHi[1] = tz;
+                    tz = nextD[0];
+                    nextD[0] = nextD[1];
+                    nextD[1] = tz;
                 }
-                if nextHi[1 as c_int as usize] - nextLo[1 as c_int as usize]
-                    < nextHi[2 as c_int as usize] - nextLo[2 as c_int as usize]
-                {
+                if nextHi[1] - nextLo[1] < nextHi[2] - nextLo[2] {
                     let mut tz_0: i32;
-                    tz_0 = nextLo[1 as c_int as usize];
-                    nextLo[1 as c_int as usize] = nextLo[2 as c_int as usize];
-                    nextLo[2 as c_int as usize] = tz_0;
-                    tz_0 = nextHi[1 as c_int as usize];
-                    nextHi[1 as c_int as usize] = nextHi[2 as c_int as usize];
-                    nextHi[2 as c_int as usize] = tz_0;
-                    tz_0 = nextD[1 as c_int as usize];
-                    nextD[1 as c_int as usize] = nextD[2 as c_int as usize];
-                    nextD[2 as c_int as usize] = tz_0;
+                    tz_0 = nextLo[1];
+                    nextLo[1] = nextLo[2];
+                    nextLo[2] = tz_0;
+                    tz_0 = nextHi[1];
+                    nextHi[1] = nextHi[2];
+                    nextHi[2] = tz_0;
+                    tz_0 = nextD[1];
+                    nextD[1] = nextD[2];
+                    nextD[2] = tz_0;
                 }
-                if nextHi[0 as c_int as usize] - nextLo[0 as c_int as usize]
-                    < nextHi[1 as c_int as usize] - nextLo[1 as c_int as usize]
-                {
+                if nextHi[0] - nextLo[0] < nextHi[1] - nextLo[1] {
                     let mut tz_1: i32;
-                    tz_1 = nextLo[0 as c_int as usize];
-                    nextLo[0 as c_int as usize] = nextLo[1 as c_int as usize];
-                    nextLo[1 as c_int as usize] = tz_1;
-                    tz_1 = nextHi[0 as c_int as usize];
-                    nextHi[0 as c_int as usize] = nextHi[1 as c_int as usize];
-                    nextHi[1 as c_int as usize] = tz_1;
-                    tz_1 = nextD[0 as c_int as usize];
-                    nextD[0 as c_int as usize] = nextD[1 as c_int as usize];
-                    nextD[1 as c_int as usize] = tz_1;
+                    tz_1 = nextLo[0];
+                    nextLo[0] = nextLo[1];
+                    nextLo[1] = tz_1;
+                    tz_1 = nextHi[0];
+                    nextHi[0] = nextHi[1];
+                    nextHi[1] = tz_1;
+                    tz_1 = nextD[0];
+                    nextD[0] = nextD[1];
+                    nextD[1] = tz_1;
                 }
-                stackLo[sp as usize] = nextLo[0 as c_int as usize];
-                stackHi[sp as usize] = nextHi[0 as c_int as usize];
-                stackD[sp as usize] = nextD[0 as c_int as usize];
+                stackLo[sp as usize] = nextLo[0];
+                stackHi[sp as usize] = nextHi[0];
+                stackD[sp as usize] = nextD[0];
                 sp += 1;
-                stackLo[sp as usize] = nextLo[1 as c_int as usize];
-                stackHi[sp as usize] = nextHi[1 as c_int as usize];
-                stackD[sp as usize] = nextD[1 as c_int as usize];
+                stackLo[sp as usize] = nextLo[1];
+                stackHi[sp as usize] = nextHi[1];
+                stackD[sp as usize] = nextD[1];
                 sp += 1;
-                stackLo[sp as usize] = nextLo[2 as c_int as usize];
-                stackHi[sp as usize] = nextHi[2 as c_int as usize];
-                stackD[sp as usize] = nextD[2 as c_int as usize];
+                stackLo[sp as usize] = nextLo[2];
+                stackHi[sp as usize] = nextHi[2];
+                stackD[sp as usize] = nextD[2];
                 sp += 1;
             }
         }

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -632,9 +632,7 @@ fn mainQSort3(
                     match n.cmp(&0) {
                         Ordering::Greater => break,
                         Ordering::Equal => {
-                            let zztmp: i32 = ptr[unLo as usize] as i32;
-                            ptr[unLo as usize] = ptr[ltLo as usize];
-                            ptr[ltLo as usize] = zztmp as u32;
+                            ptr.swap(unLo as usize, ltLo as usize);
                             ltLo += 1;
                             unLo += 1;
                         }
@@ -646,9 +644,7 @@ fn mainQSort3(
                     match n.cmp(&0) {
                         Ordering::Less => break,
                         Ordering::Equal => {
-                            let zztmp_0: i32 = ptr[unHi as usize] as i32;
-                            ptr[unHi as usize] = ptr[gtHi as usize];
-                            ptr[gtHi as usize] = zztmp_0 as u32;
+                            ptr.swap(unHi as usize, gtHi as usize);
                             gtHi -= 1;
                             unHi -= 1;
                         }
@@ -658,9 +654,7 @@ fn mainQSort3(
                 if unLo > unHi {
                     break;
                 }
-                let zztmp_1: i32 = ptr[unLo as usize] as i32;
-                ptr[unLo as usize] = ptr[unHi as usize];
-                ptr[unHi as usize] = zztmp_1 as u32;
+                ptr.swap(unLo as usize, unHi as usize);
                 unLo += 1;
                 unHi -= 1;
             }
@@ -677,9 +671,7 @@ fn mainQSort3(
                 let mut yyp2: i32 = unLo - n;
                 let mut yyn: i32 = n;
                 while yyn > 0 {
-                    let zztmp_2: i32 = ptr[yyp1 as usize] as i32;
-                    ptr[yyp1 as usize] = ptr[yyp2 as usize];
-                    ptr[yyp2 as usize] = zztmp_2 as u32;
+                    ptr.swap(yyp1 as usize, yyp2 as usize);
                     yyp1 += 1;
                     yyp2 += 1;
                     yyn -= 1;
@@ -693,9 +685,7 @@ fn mainQSort3(
                 let mut yyp2_0: i32 = hi - m + 1;
                 let mut yyn_0: i32 = m;
                 while yyn_0 > 0 {
-                    let zztmp_3: i32 = ptr[yyp1_0 as usize] as i32;
-                    ptr[yyp1_0 as usize] = ptr[yyp2_0 as usize];
-                    ptr[yyp2_0 as usize] = zztmp_3 as u32;
+                    ptr.swap(yyp1_0 as usize, yyp2_0 as usize);
                     yyp1_0 += 1;
                     yyp2_0 += 1;
                     yyn_0 -= 1;

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -467,15 +467,12 @@ fn mainSimpleSort(
 
     for &h in INCS[..index].iter().rev() {
         i = lo + h;
-        loop {
-            if i > hi {
-                break;
-            }
+        while i <= hi {
             v = ptr[i as usize];
             j = i;
             while mainGtU(
-                (ptr[(j - h) as usize]).wrapping_add(d as c_uint),
-                v.wrapping_add(d as c_uint),
+                (ptr[(j - h) as usize]).wrapping_add(d as u32),
+                v.wrapping_add(d as u32),
                 block,
                 quadrant,
                 nblock as u32,
@@ -483,55 +480,13 @@ fn mainSimpleSort(
             ) {
                 ptr[j as usize] = ptr[(j - h) as usize];
                 j -= h;
-                if j <= lo + h - 1 as c_int {
+                if j <= lo + h - 1 {
                     break;
                 }
             }
             ptr[j as usize] = v;
             i += 1;
-            if i > hi {
-                break;
-            }
-            v = ptr[i as usize];
-            j = i;
-            while mainGtU(
-                (ptr[(j - h) as usize]).wrapping_add(d as c_uint),
-                v.wrapping_add(d as c_uint),
-                block,
-                quadrant,
-                nblock as u32,
-                budget,
-            ) {
-                ptr[j as usize] = ptr[(j - h) as usize];
-                j -= h;
-                if j <= lo + h - 1 as c_int {
-                    break;
-                }
-            }
-            ptr[j as usize] = v;
-            i += 1;
-            if i > hi {
-                break;
-            }
-            v = ptr[i as usize];
-            j = i;
-            while mainGtU(
-                (ptr[(j - h) as usize]).wrapping_add(d as c_uint),
-                v.wrapping_add(d as c_uint),
-                block,
-                quadrant,
-                nblock as u32,
-                budget,
-            ) {
-                ptr[j as usize] = ptr[(j - h) as usize];
-                j -= h;
-                if j <= lo + h - 1 as c_int {
-                    break;
-                }
-            }
-            ptr[j as usize] = v;
-            i += 1;
-            if *budget < 0 as c_int {
+            if *budget < 0 {
                 return;
             }
         }

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -632,17 +632,16 @@ fn mainQSort3(
                         break;
                     }
                     n = block[(ptr[unLo as usize]).wrapping_add(d as c_uint) as usize] as i32 - med;
-                    if n == 0 {
-                        let zztmp: i32 = ptr[unLo as usize] as i32;
-                        ptr[unLo as usize] = ptr[ltLo as usize];
-                        ptr[ltLo as usize] = zztmp as u32;
-                        ltLo += 1;
-                        unLo += 1;
-                    } else {
-                        if n > 0 {
-                            break;
+                    match n.cmp(&0) {
+                        Ordering::Greater => break,
+                        Ordering::Equal => {
+                            let zztmp: i32 = ptr[unLo as usize] as i32;
+                            ptr[unLo as usize] = ptr[ltLo as usize];
+                            ptr[ltLo as usize] = zztmp as u32;
+                            ltLo += 1;
+                            unLo += 1;
                         }
-                        unLo += 1;
+                        Ordering::Less => unLo += 1,
                     }
                 }
                 loop {
@@ -650,17 +649,16 @@ fn mainQSort3(
                         break;
                     }
                     n = block[(ptr[unHi as usize]).wrapping_add(d as c_uint) as usize] as i32 - med;
-                    if n == 0 {
-                        let zztmp_0: i32 = ptr[unHi as usize] as i32;
-                        ptr[unHi as usize] = ptr[gtHi as usize];
-                        ptr[gtHi as usize] = zztmp_0 as u32;
-                        gtHi -= 1;
-                        unHi -= 1;
-                    } else {
-                        if n < 0 {
-                            break;
+                    match n.cmp(&0) {
+                        Ordering::Less => break,
+                        Ordering::Equal => {
+                            let zztmp_0: i32 = ptr[unHi as usize] as i32;
+                            ptr[unHi as usize] = ptr[gtHi as usize];
+                            ptr[gtHi as usize] = zztmp_0 as u32;
+                            gtHi -= 1;
+                            unHi -= 1;
                         }
-                        unHi -= 1;
+                        Ordering::Greater => unHi -= 1,
                     }
                 }
                 if unLo > unHi {


### PR DESCRIPTION
Mostly to reduce the linecount, but it turns out that the unrolling in `mainSimpleSort` was actually bad, and having the compiler do it for us is quite a bit faster.

```
Benchmark 2 (7 runs): target/relwithdebinfo/examples/compress rs 1 /home/folkertdev/rust/zlib-rs/silesia-small.tar
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           739ms ± 2.65ms     736ms …  744ms          0 ( 0%)        ⚡-  3.3% ±  0.6%
  peak_rss           24.5MB ± 49.5KB    24.4MB … 24.5MB          1 (14%)          -  0.1% ±  0.2%
  cpu_cycles         3.34G  ± 11.3M     3.33G  … 3.37G           0 ( 0%)        ⚡-  3.0% ±  0.4%
  instructions       8.82G  ± 23.1K     8.82G  … 8.82G           1 (14%)        ⚡-  5.7% ±  0.0%
  cache_references    157M  ± 3.20M      153M  …  163M           0 ( 0%)          +  0.4% ±  1.9%
  cache_misses       22.0M  ± 2.03M     20.5M  … 26.2M           0 ( 0%)          +  2.2% ±  8.4%
  branch_misses      50.7M  ± 22.7K     50.7M  … 50.7M           0 ( 0%)        ⚡-  1.7% ±  0.1%
```