### PR TITLE
read coding tables in one go if there is sufficient input

### DIFF
--- a/libbz2-rs-sys/src/decompress.rs
+++ b/libbz2-rs-sys/src/decompress.rs
@@ -1015,9 +1015,9 @@ pub(crate) fn decompress(
                             let bytes_needed = bits_needed.div_ceil(8);
 
                             if strm.avail_in as usize >= bytes_needed {
-                                for t in 0..nGroups {
+                                for t in 0..usize::from(nGroups) {
                                     let mut curr = GET_BITS!(strm, s, 5);
-                                    for i in 0..alphaSize {
+                                    for i in 0..usize::from(alphaSize) {
                                         loop {
                                             if !(1..=20).contains(&curr) {
                                                 error!(BZ_DATA_ERROR);
@@ -1031,7 +1031,7 @@ pub(crate) fn decompress(
                                             }
                                         }
 
-                                        s.len[usize::from(t)][usize::from(i)] = curr as u8;
+                                        s.len[t][i] = curr as u8;
                                     }
                                 }
 


### PR DESCRIPTION
especially for smaller files this is an improvement

```
Benchmark 2 (180 runs): target/relwithdebinfo/examples/decompress rs tests/input/bzip2-testfiles/dotnetzip/dancing-color.ps.bz2
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          27.9ms ±  352us    27.2ms … 31.0ms          2 ( 1%)        ⚡-  2.3% ±  0.3%
  peak_rss           7.54MB ± 67.0KB    7.34MB … 7.60MB          0 ( 0%)          +  0.0% ±  0.2%
  cpu_cycles          113M  ± 1.08M      112M  …  125M          11 ( 6%)        ⚡-  2.6% ±  0.3%
  instructions        205M  ±  289       205M  …  205M           0 ( 0%)        ⚡-  3.0% ±  0.0%
  cache_references   2.49M  ± 17.8K     2.47M  … 2.61M          35 (19%)          +  0.9% ±  0.2%
  cache_misses        545K  ± 2.69K      538K  …  561K           4 ( 2%)        💩+  4.0% ±  0.2%
  branch_misses       948K  ± 1.99K      942K  …  957K           7 ( 4%)        ⚡- 15.5% ±  0.1%
```

(CI benchmarks just show noise...)

