### PR TITLE
remove `#![allow(clippy::needless_range_loop)]`

### DIFF
--- a/libbz2-rs-sys/src/bzlib.rs
+++ b/libbz2-rs-sys/src/bzlib.rs
@@ -479,7 +479,7 @@ pub(crate) struct EState {
     pub selector: [u8; 18002],
     pub selectorMtf: [u8; 18002],
     pub len: [[u8; BZ_MAX_ALPHA_SIZE]; BZ_N_GROUPS],
-    pub code: [[i32; 258]; 6],
+    pub code: [[u32; 258]; 6],
     pub rfreq: [[i32; 258]; 6],
     pub len_pack: [[u32; 4]; 258],
 }

--- a/libbz2-rs-sys/src/compress.rs
+++ b/libbz2-rs-sys/src/compress.rs
@@ -560,34 +560,18 @@ fn send_mtf_values(s: &mut EState) {
         assert_h!((s.selector[selCtr] as usize) < nGroups, 3006);
         if nGroups == 6 && 50 == ge - gs + 1 {
             /*--- fast track the common case ---*/
-            let mut mtfv_i: u16;
 
             let s_len_sel_selCtr = s.len[s.selector[selCtr] as usize];
             let s_code_sel_selCtr = s.code[s.selector[selCtr] as usize];
 
-            macro_rules! BZ_ITAH {
-                ($nn:expr) => {
-                    mtfv_i = mtfv[(gs + $nn) as usize];
+            for chunk in mtfv[gs as usize..][..50].chunks_exact(10) {
+                for &mtfv_i in chunk {
                     writer.write(
-                        s_len_sel_selCtr[mtfv_i as usize] as i32,
-                        s_code_sel_selCtr[mtfv_i as usize],
+                        s_len_sel_selCtr[usize::from(mtfv_i)] as i32,
+                        s_code_sel_selCtr[usize::from(mtfv_i)],
                     );
-                };
+                }
             }
-
-            #[rustfmt::skip]
-            {
-                BZ_ITAH!(0);  BZ_ITAH!(1);  BZ_ITAH!(2);  BZ_ITAH!(3);  BZ_ITAH!(4);
-                BZ_ITAH!(5);  BZ_ITAH!(6);  BZ_ITAH!(7);  BZ_ITAH!(8);  BZ_ITAH!(9);
-                BZ_ITAH!(10); BZ_ITAH!(11); BZ_ITAH!(12); BZ_ITAH!(13); BZ_ITAH!(14);
-                BZ_ITAH!(15); BZ_ITAH!(16); BZ_ITAH!(17); BZ_ITAH!(18); BZ_ITAH!(19);
-                BZ_ITAH!(20); BZ_ITAH!(21); BZ_ITAH!(22); BZ_ITAH!(23); BZ_ITAH!(24);
-                BZ_ITAH!(25); BZ_ITAH!(26); BZ_ITAH!(27); BZ_ITAH!(28); BZ_ITAH!(29);
-                BZ_ITAH!(30); BZ_ITAH!(31); BZ_ITAH!(32); BZ_ITAH!(33); BZ_ITAH!(34);
-                BZ_ITAH!(35); BZ_ITAH!(36); BZ_ITAH!(37); BZ_ITAH!(38); BZ_ITAH!(39);
-                BZ_ITAH!(40); BZ_ITAH!(41); BZ_ITAH!(42); BZ_ITAH!(43); BZ_ITAH!(44);
-                BZ_ITAH!(45); BZ_ITAH!(46); BZ_ITAH!(47); BZ_ITAH!(48); BZ_ITAH!(49);
-            };
         } else {
             /*--- slow version which correctly handles all situations ---*/
             for i in gs..=ge {

--- a/libbz2-rs-sys/src/compress.rs
+++ b/libbz2-rs-sys/src/compress.rs
@@ -203,15 +203,12 @@ fn send_mtf_values(s: &mut EState) {
     const BZ_LESSER_ICOST: u8 = 0;
     const BZ_GREATER_ICOST: u8 = 15;
 
-    let mut j: i32;
     let mut gs: i32;
     let mut ge: i32;
     let mut totc: i32;
     let mut bt: i32;
     let mut bc: i32;
     let mut nSelectors: usize = 0;
-    let mut minLen: i32;
-    let mut maxLen: i32;
     let mut selCtr: usize;
     let mut nBytes: i32;
 
@@ -451,18 +448,13 @@ fn send_mtf_values(s: &mut EState) {
 
     /*--- Compute MTF values for the selectors. ---*/
     {
-        let mut pos: [u8; BZ_N_GROUPS] = [0; BZ_N_GROUPS];
-        let mut ll_i: u8;
+        let mut pos: [u8; BZ_N_GROUPS] = [0, 1, 2, 3, 4, 5];
+
         let mut tmp2: u8;
         let mut tmp: u8;
 
-        for i in 0..nGroups {
-            pos[i] = i as u8;
-        }
-
-        for i in 0..nSelectors {
-            ll_i = s.selector[i];
-            j = 0;
+        for (i, &ll_i) in s.selector[..nSelectors].iter().enumerate() {
+            let mut j = 0;
             tmp = pos[j as usize];
             while ll_i != tmp {
                 j += 1;
@@ -476,19 +468,19 @@ fn send_mtf_values(s: &mut EState) {
     }
 
     /*--- Assign actual codes for the tables. --*/
-    for t in 0..nGroups {
-        minLen = 32;
-        maxLen = 0;
+    for (t, len) in s.len[..nGroups].iter().enumerate() {
+        let mut minLen = 32;
+        let mut maxLen = 0;
 
-        for i in 0..alphaSize {
-            maxLen = Ord::max(maxLen, s.len[t][i] as i32);
-            minLen = Ord::min(minLen, s.len[t][i] as i32);
+        for &l in &len[..alphaSize] {
+            maxLen = Ord::max(maxLen, l as i32);
+            minLen = Ord::min(minLen, l as i32);
         }
 
         assert_h!(maxLen <= 17, 3004);
         assert_h!(minLen >= 1, 3005);
 
-        huffman::assign_codes(&mut s.code[t], &s.len[t], minLen, maxLen, alphaSize);
+        huffman::assign_codes(&mut s.code[t], len, minLen, maxLen, alphaSize);
     }
 
     /*--- Transmit the mapping table. ---*/

--- a/libbz2-rs-sys/src/compress.rs
+++ b/libbz2-rs-sys/src/compress.rs
@@ -371,8 +371,8 @@ fn send_mtf_values(s: &mut EState) {
                 for i in gs..=ge {
                     let icv_0: u16 = mtfv[i as usize];
 
-                    for t in 0..nGroups {
-                        cost[t] = (cost[t] as i32 + s.len[t][icv_0 as usize] as i32) as u16;
+                    for (t, c) in cost.iter_mut().enumerate() {
+                        *c = (*c as i32 + s.len[t][icv_0 as usize] as i32) as u16;
                     }
                 }
             }
@@ -383,9 +383,9 @@ fn send_mtf_values(s: &mut EState) {
             --*/
             bc = 999999999;
             bt = -1;
-            for t in 0..nGroups {
-                if (cost[t] as i32) < bc {
-                    bc = cost[t] as i32;
+            for (t, &c) in cost.iter().enumerate() {
+                if (c as i32) < bc {
+                    bc = c as i32;
                     bt = t as i32;
                 }
             }
@@ -429,8 +429,8 @@ fn send_mtf_values(s: &mut EState) {
                 iter + 1,
                 totc / 8,
             );
-            for t in 0..nGroups {
-                debug_log!("{} ", fave[t],);
+            for f in fave.iter() {
+                debug_log!("{} ", f);
             }
             debug_logln!();
         }

--- a/libbz2-rs-sys/src/compress.rs
+++ b/libbz2-rs-sys/src/compress.rs
@@ -570,7 +570,7 @@ fn send_mtf_values(s: &mut EState) {
                     mtfv_i = mtfv[(gs + $nn) as usize];
                     writer.write(
                         s_len_sel_selCtr[mtfv_i as usize] as i32,
-                        s_code_sel_selCtr[mtfv_i as usize] as u32,
+                        s_code_sel_selCtr[mtfv_i as usize],
                     );
                 };
             }

--- a/libbz2-rs-sys/src/compress.rs
+++ b/libbz2-rs-sys/src/compress.rs
@@ -392,25 +392,11 @@ fn send_mtf_values(s: &mut EState) {
             nSelectors += 1;
 
             if nGroups == 6 && 50 == ge - gs + 1 {
-                macro_rules! BZ_ITUR {
-                    ($nn:expr) => {
-                        s.rfreq[bt as usize][mtfv[(gs + $nn) as usize] as usize] += 1;
-                    };
+                for chunk in mtfv[gs as usize..][..50].chunks_exact(10) {
+                    for &mtfv_i in chunk {
+                        s.rfreq[bt as usize][usize::from(mtfv_i)] += 1;
+                    }
                 }
-
-                #[rustfmt::skip]
-                {
-                    BZ_ITUR!(0);  BZ_ITUR!(1);  BZ_ITUR!(2);  BZ_ITUR!(3);  BZ_ITUR!(4);
-                    BZ_ITUR!(5);  BZ_ITUR!(6);  BZ_ITUR!(7);  BZ_ITUR!(8);  BZ_ITUR!(9);
-                    BZ_ITUR!(10); BZ_ITUR!(11); BZ_ITUR!(12); BZ_ITUR!(13); BZ_ITUR!(14);
-                    BZ_ITUR!(15); BZ_ITUR!(16); BZ_ITUR!(17); BZ_ITUR!(18); BZ_ITUR!(19);
-                    BZ_ITUR!(20); BZ_ITUR!(21); BZ_ITUR!(22); BZ_ITUR!(23); BZ_ITUR!(24);
-                    BZ_ITUR!(25); BZ_ITUR!(26); BZ_ITUR!(27); BZ_ITUR!(28); BZ_ITUR!(29);
-                    BZ_ITUR!(30); BZ_ITUR!(31); BZ_ITUR!(32); BZ_ITUR!(33); BZ_ITUR!(34);
-                    BZ_ITUR!(35); BZ_ITUR!(36); BZ_ITUR!(37); BZ_ITUR!(38); BZ_ITUR!(39);
-                    BZ_ITUR!(40); BZ_ITUR!(41); BZ_ITUR!(42); BZ_ITUR!(43); BZ_ITUR!(44);
-                    BZ_ITUR!(45); BZ_ITUR!(46); BZ_ITUR!(47); BZ_ITUR!(48); BZ_ITUR!(49);
-                };
             } else {
                 for i in gs..=ge {
                     s.rfreq[bt as usize][mtfv[i as usize] as usize] += 1;

--- a/libbz2-rs-sys/src/compress.rs
+++ b/libbz2-rs-sys/src/compress.rs
@@ -42,7 +42,7 @@ impl<'a> LiveWriter<'a> {
         self.bs_buff = 0;
     }
 
-    #[inline(always)]
+    #[inline]
     fn finish(&mut self) {
         while self.bs_live > 0 {
             self.zbits[self.num_z as usize] = (self.bs_buff >> 24) as u8;
@@ -52,7 +52,7 @@ impl<'a> LiveWriter<'a> {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     fn flush_whole_bytes(&mut self) {
         let range = self.num_z as usize..self.num_z as usize + 4;
         if let Some(dst) = self.zbits.get_mut(range) {

--- a/libbz2-rs-sys/src/compress.rs
+++ b/libbz2-rs-sys/src/compress.rs
@@ -356,30 +356,15 @@ fn send_mtf_values(s: &mut EState) {
                 let mut cost01: u32 = 0;
                 let mut cost23: u32 = 0;
                 let mut cost45: u32 = 0;
-                let mut icv: u16;
 
-                macro_rules! BZ_ITER {
-                    ($nn:expr) => {
-                        icv = mtfv[(gs + $nn) as usize];
-                        cost01 = cost01.wrapping_add(s.len_pack[icv as usize][0]);
-                        cost23 = cost23.wrapping_add(s.len_pack[icv as usize][1]);
-                        cost45 = cost45.wrapping_add(s.len_pack[icv as usize][2]);
-                    };
+                for chunk in mtfv[gs as usize..][..50].chunks_exact(5) {
+                    for icv in chunk {
+                        let [a, b, c, _] = s.len_pack[usize::from(*icv)];
+                        cost01 = cost01.wrapping_add(a);
+                        cost23 = cost23.wrapping_add(b);
+                        cost45 = cost45.wrapping_add(c);
+                    }
                 }
-
-                #[rustfmt::skip]
-                {
-                    BZ_ITER!(0);  BZ_ITER!(1);  BZ_ITER!(2);  BZ_ITER!(3);  BZ_ITER!(4);
-                    BZ_ITER!(5);  BZ_ITER!(6);  BZ_ITER!(7);  BZ_ITER!(8);  BZ_ITER!(9);
-                    BZ_ITER!(10); BZ_ITER!(11); BZ_ITER!(12); BZ_ITER!(13); BZ_ITER!(14);
-                    BZ_ITER!(15); BZ_ITER!(16); BZ_ITER!(17); BZ_ITER!(18); BZ_ITER!(19);
-                    BZ_ITER!(20); BZ_ITER!(21); BZ_ITER!(22); BZ_ITER!(23); BZ_ITER!(24);
-                    BZ_ITER!(25); BZ_ITER!(26); BZ_ITER!(27); BZ_ITER!(28); BZ_ITER!(29);
-                    BZ_ITER!(30); BZ_ITER!(31); BZ_ITER!(32); BZ_ITER!(33); BZ_ITER!(34);
-                    BZ_ITER!(35); BZ_ITER!(36); BZ_ITER!(37); BZ_ITER!(38); BZ_ITER!(39);
-                    BZ_ITER!(40); BZ_ITER!(41); BZ_ITER!(42); BZ_ITER!(43); BZ_ITER!(44);
-                    BZ_ITER!(45); BZ_ITER!(46); BZ_ITER!(47); BZ_ITER!(48); BZ_ITER!(49);
-                };
 
                 cost[0] = (cost01 & 0xffff) as u16;
                 cost[1] = (cost01 >> 16) as u16;

--- a/libbz2-rs-sys/src/compress.rs
+++ b/libbz2-rs-sys/src/compress.rs
@@ -469,18 +469,20 @@ fn send_mtf_values(s: &mut EState) {
 
     /*--- Assign actual codes for the tables. --*/
     for (t, len) in s.len[..nGroups].iter().enumerate() {
+        let len = &len[..alphaSize];
+
         let mut minLen = 32;
         let mut maxLen = 0;
 
-        for &l in &len[..alphaSize] {
-            maxLen = Ord::max(maxLen, l as i32);
-            minLen = Ord::min(minLen, l as i32);
+        for &l in len {
+            maxLen = Ord::max(maxLen, l);
+            minLen = Ord::min(minLen, l);
         }
 
         assert_h!(maxLen <= 17, 3004);
         assert_h!(minLen >= 1, 3005);
 
-        huffman::assign_codes(&mut s.code[t], len, minLen, maxLen, alphaSize);
+        huffman::assign_codes(&mut s.code[t], len, minLen, maxLen);
     }
 
     /*--- Transmit the mapping table. ---*/

--- a/libbz2-rs-sys/src/compress.rs
+++ b/libbz2-rs-sys/src/compress.rs
@@ -71,11 +71,11 @@ impl<'a> LiveWriter<'a> {
         }
     }
 
-    fn write(&mut self, n: i32, v: u32) {
+    fn write(&mut self, n: u8, v: u32) {
         self.flush_whole_bytes();
 
-        self.bs_buff |= v << (32 - self.bs_live - n);
-        self.bs_live += n;
+        self.bs_buff |= v << (32 - self.bs_live - i32::from(n));
+        self.bs_live += i32::from(n);
     }
 
     fn write_u8(&mut self, c: u8) {
@@ -568,7 +568,7 @@ fn send_mtf_values(s: &mut EState) {
             for chunk in mtfv[gs as usize..][..50].chunks_exact(10) {
                 for &mtfv_i in chunk {
                     writer.write(
-                        s_len_sel_selCtr[usize::from(mtfv_i)] as i32,
+                        s_len_sel_selCtr[usize::from(mtfv_i)],
                         s_code_sel_selCtr[usize::from(mtfv_i)],
                     );
                 }
@@ -577,8 +577,8 @@ fn send_mtf_values(s: &mut EState) {
             /*--- slow version which correctly handles all situations ---*/
             for i in gs..=ge {
                 writer.write(
-                    s.len[s.selector[selCtr] as usize][mtfv[i as usize] as usize] as i32,
-                    s.code[s.selector[selCtr] as usize][mtfv[i as usize] as usize] as u32,
+                    s.len[s.selector[selCtr] as usize][mtfv[i as usize] as usize],
+                    s.code[s.selector[selCtr] as usize][mtfv[i as usize] as usize],
                 );
             }
         }

--- a/libbz2-rs-sys/src/huffman.rs
+++ b/libbz2-rs-sys/src/huffman.rs
@@ -155,17 +155,12 @@ pub(crate) fn make_code_lengths(len: &mut [u8], freq: &[i32], alphaSize: usize, 
     }
 }
 
-pub(crate) fn assign_codes(
-    code: &mut [i32],
-    length: &[u8],
-    minLen: i32,
-    maxLen: i32,
-    alphaSize: usize,
-) {
+#[inline(always)]
+pub(crate) fn assign_codes(code: &mut [i32], length: &[u8], minLen: u8, maxLen: u8) {
     let mut vec: i32 = 0;
     for n in minLen..=maxLen {
-        for i in 0..alphaSize {
-            if length[i] as i32 == n {
+        for (i, &l) in length.iter().enumerate() {
+            if l == n {
                 code[i] = vec;
                 vec += 1;
             }

--- a/libbz2-rs-sys/src/huffman.rs
+++ b/libbz2-rs-sys/src/huffman.rs
@@ -155,7 +155,7 @@ pub(crate) fn make_code_lengths(len: &mut [u8], freq: &[i32], alphaSize: usize, 
     }
 }
 
-#[inline(always)]
+#[inline]
 pub(crate) fn assign_codes(code: &mut [u32], length: &[u8], minLen: u8, maxLen: u8) {
     let mut vec: u32 = 0;
     for n in minLen..=maxLen {

--- a/libbz2-rs-sys/src/huffman.rs
+++ b/libbz2-rs-sys/src/huffman.rs
@@ -156,8 +156,8 @@ pub(crate) fn make_code_lengths(len: &mut [u8], freq: &[i32], alphaSize: usize, 
 }
 
 #[inline(always)]
-pub(crate) fn assign_codes(code: &mut [i32], length: &[u8], minLen: u8, maxLen: u8) {
-    let mut vec: i32 = 0;
+pub(crate) fn assign_codes(code: &mut [u32], length: &[u8], minLen: u8, maxLen: u8) {
+    let mut vec: u32 = 0;
     for n in minLen..=maxLen {
         for (i, &l) in length.iter().enumerate() {
             if l == n {

--- a/libbz2-rs-sys/src/lib.rs
+++ b/libbz2-rs-sys/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![allow(non_snake_case)]
 #![allow(clippy::too_many_arguments)]
-#![allow(clippy::needless_range_loop)] // FIXME remove once all instances are fixed
 #![deny(unreachable_pub)]
 #![deny(unsafe_op_in_unsafe_fn)]
 


### PR DESCRIPTION
Clean up the loops, and some various other things along the way. Optimizing `write` gives some small gains:

```
Benchmark 2 (7 runs): target/relwithdebinfo/examples/compress rs 1 /home/folkertdev/rust/zlib-rs/silesia-small.tar
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           743ms ± 2.23ms     741ms …  747ms          0 ( 0%)        ⚡-  2.0% ±  0.4%
  peak_rss           24.5MB ± 70.1KB    24.4MB … 24.5MB          0 ( 0%)          -  0.0% ±  0.3%
  cpu_cycles         3.37G  ± 10.0M     3.36G  … 3.39G           0 ( 0%)        ⚡-  2.0% ±  0.4%
  instructions       9.11G  ± 31.6K     9.11G  … 9.11G           0 ( 0%)        ⚡-  2.6% ±  0.0%
  cache_references    156M  ± 1.95M      153M  …  159M           0 ( 0%)          -  2.1% ±  1.3%
  cache_misses       21.0M  ±  757K     19.6M  … 22.0M           0 ( 0%)        ⚡- 12.5% ±  4.5%
  branch_misses      49.1M  ± 36.7K     49.0M  … 49.1M           0 ( 0%)        ⚡-  4.7% ±  0.1%
```