### PR TITLE
add `semver-prefix` feature for use by `bzip2-rs`

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -344,6 +344,11 @@ jobs:
         run: |
           cargo build --release --target ${{matrix.target}} --features=custom-prefix
           objdump -tT target/${{matrix.target}}/release/deps/libbz2_rs.so | grep -q "MY_CUSTOM_PREFIX_BZ2_bzCompressInit" || (echo "symbol not found!" && exit 1)
+      - name: "cdylib: semver-prefix"
+        working-directory: libbz2-rs-sys-cdylib
+        run: |
+          cargo build --release --target ${{matrix.target}} --features=semver-prefix
+          objdump -tT target/${{matrix.target}}/release/deps/libbz2_rs.so | grep -q -E "LIBBZ2_RS_SYS_v0.[0-9]+.x_BZ2_bzCompressInit" || (echo "symbol not found!" && exit 1)
 
   cargo-c-dynamic-library:
     name: cargo-c dynamic library

--- a/libbz2-rs-sys-cdylib/Cargo.lock
+++ b/libbz2-rs-sys-cdylib/Cargo.lock
@@ -4,14 +4,14 @@ version = 3
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "libbz2-rs-sys-cdylib"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "libbz2-rs-sys",
  "libc",

--- a/libbz2-rs-sys-cdylib/Cargo.toml
+++ b/libbz2-rs-sys-cdylib/Cargo.toml
@@ -20,6 +20,7 @@ bench = false
 default = ["stdio"]
 stdio = ["libbz2-rs-sys/stdio"]
 custom-prefix = ["libbz2-rs-sys/custom-prefix"] # use the LIBBZ2_RS_SYS_PREFIX to prefix all exported symbols
+semver-prefix = ["libbz2-rs-sys/semver-prefix"] # prefix all symbols in a semver-compatible way
 capi = []
 
 [dependencies]

--- a/libbz2-rs-sys/Cargo.toml
+++ b/libbz2-rs-sys/Cargo.toml
@@ -17,6 +17,7 @@ rust-allocator = [] # use the rust global allocator (rust is picked over c if bo
 std = ["rust-allocator"]
 custom-prefix = [] # use the LIBBZ2_RS_SYS_PREFIX to prefix all exported symbols
 testing-prefix = [] # prefix all symbols with LIBBZ2_RS_SYS_TEST_ for testing
+semver-prefix = [] # prefix all symbols in a semver-compatible way
 stdio = ["dep:libc"] # corresponds to BZ_NO_STDIO; only the low-level api is available when this flag is disabled
 __internal-fuzz-disable-checksum = []
 

--- a/libbz2-rs-sys/src/bzlib.rs
+++ b/libbz2-rs-sys/src/bzlib.rs
@@ -45,8 +45,27 @@ macro_rules! prefix {
     };
 }
 
+// NOTE: once we reach 1.0.0, the macro used for the `semver-prefix` feature should no longer include the
+// minor version in the name. The name is meant to be unique between semver-compatible versions!
+const _PRE_ONE_DOT_O: () = assert!(env!("CARGO_PKG_VERSION_MAJOR").as_bytes()[0] == b'0');
+
+#[cfg(feature = "semver-prefix")]
+macro_rules! prefix {
+    ($name:expr) => {
+        concat!(
+            "LIBBZ2_RS_SYS_v",
+            env!("CARGO_PKG_VERSION_MAJOR"),
+            ".",
+            env!("CARGO_PKG_VERSION_MINOR"),
+            ".x_",
+            stringify!($name)
+        )
+    };
+}
+
 #[cfg(all(
     not(feature = "custom-prefix"),
+    not(feature = "semver-prefix"),
     not(any(test, feature = "testing-prefix"))
 ))]
 macro_rules! prefix {
@@ -55,7 +74,11 @@ macro_rules! prefix {
     };
 }
 
-#[cfg(all(not(feature = "custom-prefix"), any(test, feature = "testing-prefix")))]
+#[cfg(all(
+    not(feature = "custom-prefix"),
+    not(feature = "semver-prefix"),
+    any(test, feature = "testing-prefix")
+))]
 macro_rules! prefix {
     ($name:expr) => {
         concat!("LIBBZ2_RS_SYS_TEST_", stringify!($name))


### PR DESCRIPTION
related to https://github.com/trifectatechfoundation/bzip2-rs/pull/125

the current setup should work until 1.0.0, and then fail loudly if we fail to update it.