### PR TITLE
specialize `rotate_right` by 1

### DIFF
--- a/libbz2-rs-sys/src/decompress.rs
+++ b/libbz2-rs-sys/src/decompress.rs
@@ -1019,7 +1019,7 @@ pub(crate) fn decompress(
 
                             let mut pos: [u8; 6] = [0, 1, 2, 3, 4, 5];
                             for i in 0..usize::from(nSelectors) {
-                                pos[..=usize::from(s.selectorMtf[i])].rotate_right(1);
+                                rotate_right_1(&mut pos[..=usize::from(s.selectorMtf[i])]);
                                 s.selector[i] = pos[0];
                             }
 
@@ -1232,7 +1232,7 @@ fn initialize_mtfa(mtfa: &mut [u8; 4096], mtfbase: &mut [u16; 16], nextSym: u16)
         // avoid general case expense
         let pp = usize::from(mtfbase[0]);
         let uc = mtfa[pp + nn];
-        mtfa[pp..][..=nn].rotate_right(1);
+        rotate_right_1(&mut mtfa[pp..][..=nn]);
 
         uc
     } else {
@@ -1267,4 +1267,11 @@ fn initialize_mtfa(mtfa: &mut [u8; 4096], mtfbase: &mut [u16; 16], nextSym: u16)
 
         uc
     }
+}
+
+fn rotate_right_1(slice: &mut [u8]) {
+    let Some(&last) = slice.last() else { return };
+
+    slice.copy_within(0..slice.len() - 1, 1);
+    slice[0] = last;
 }


### PR DESCRIPTION
turns out the default is really not as efficient as it could be, compare

```asm
.section .text.rotate_right_1,"ax",@progbits
	.globl	rotate_right_1
	.p2align	4, 0x90
	.type	rotate_right_1,@function
rotate_right_1:
	.cfi_startproc
	push rbp
	.cfi_def_cfa_offset 16
	push rbx
	.cfi_def_cfa_offset 24
	push rax
	.cfi_def_cfa_offset 32
	.cfi_offset rbx, -24
	.cfi_offset rbp, -16
	test rsi, rsi
	je .LBB32_11
	mov rdx, rsi
	dec rdx
	je .LBB32_5
	mov rbx, rdi
	cmp rsi, 24
	jae .LBB32_3
	movzx ebp, byte ptr [rbx]
	mov eax, 1
	mov ecx, 1
	sub rcx, rsi
	xor esi, esi
	mov edi, 1
	jmp .LBB32_7
	.p2align	4, 0x90
.LBB32_8:
	inc rdi
.LBB32_7:
	mov r8d, ebp
	movzx ebp, byte ptr [rbx + rdi]
	mov byte ptr [rbx + rdi], r8b
	cmp rdi, rdx
	jb .LBB32_8
	add rdi, rcx
	je .LBB32_4
	cmp rdi, rax
	cmovb rax, rsi
	cmovb rdi, rsi
	jmp .LBB32_7
.LBB32_3:
	lea rdi, [rbx + 1]
	movzx ebp, byte ptr [rbx + rdx]
	mov rsi, rbx
	call qword ptr [rip + memmove@GOTPCREL]
.LBB32_4:
	mov byte ptr [rbx], bpl
.LBB32_5:
	add rsp, 8
	.cfi_def_cfa_offset 24
	pop rbx
	.cfi_def_cfa_offset 16
	pop rbp
	.cfi_def_cfa_offset 8
	ret
.LBB32_11:
	.cfi_def_cfa_offset 32
	lea rdi, [rip + .L__unnamed_283]
	lea rdx, [rip + .L__unnamed_284]
	mov esi, 33
	call qword ptr [rip + core::panicking::panic@GOTPCREL]
```
versus

```asm
.section .text.rotate_right_1,"ax",@progbits
	.globl	rotate_right_1
	.p2align	4, 0x90
	.type	rotate_right_1,@function
rotate_right_1:
	.cfi_startproc
	test rsi, rsi
	je .LBB32_2
	push rbp
	.cfi_def_cfa_offset 16
	push rbx
	.cfi_def_cfa_offset 24
	push rax
	.cfi_def_cfa_offset 32
	.cfi_offset rbx, -24
	.cfi_offset rbp, -16
	mov rdx, rsi
	movzx ebp, byte ptr [rdi + rsi - 1]
	dec rdx
	lea rax, [rdi + 1]
	mov rbx, rdi
	mov rdi, rax
	mov rsi, rbx
	call qword ptr [rip + memmove@GOTPCREL]
	mov byte ptr [rbx], bpl
	add rsp, 8
	.cfi_def_cfa_offset 24
	pop rbx
	.cfi_def_cfa_offset 16
	pop rbp
	.cfi_def_cfa_offset 8
	.cfi_restore rbx
	.cfi_restore rbp
.LBB32_2:
	ret 
```

This gives some good speedup on some of the examples

``` 
Benchmark 2 (8 runs): target/release/examples/decompress rs tests/input/bzip2-testfiles/commons-compress/zip64support.tar.bz2
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           697ms ± 1.69ms     695ms …  699ms          0 ( 0%)        ⚡-  2.2% ±  0.6%
  peak_rss            116MB ± 97.5KB     116MB …  116MB          0 ( 0%)          +  0.1% ±  0.1%
  cpu_cycles         2.99G  ± 8.43M     2.98G  … 3.00G           0 ( 0%)        ⚡-  2.3% ±  0.6%
  instructions       5.99G  ±  250      5.99G  … 5.99G           0 ( 0%)        ⚡-  4.1% ±  0.0%
  cache_references   91.1M  ±  173K     90.8M  … 91.3M           0 ( 0%)          -  0.5% ±  0.3%
  cache_misses       17.3M  ±  164K     17.0M  … 17.5M           1 (13%)        ⚡-  3.2% ±  0.9%
  branch_misses      7.41M  ± 19.4K     7.39M  … 7.45M           0 ( 0%)        ⚡-  5.9% ±  0.3%
```