### PR TITLE
optimize `fallback_sort`

### DIFF
--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -338,10 +338,10 @@ fn fallbackSort(
 
                 /*-- scan bucket and generate header bits-- */
                 let mut cc = -1;
-                for i in l..=r {
-                    let cc1 = arr2.eclass()[fmap[i as usize] as usize] as i32;
+                for (i, x) in fmap[l as usize..=r as usize].iter().enumerate() {
+                    let cc1 = arr2.eclass()[*x as usize] as i32;
                     if cc != cc1 {
-                        SET_BH!(i);
+                        SET_BH!(l + i as i32);
                         cc = cc1;
                     }
                 }


### PR DESCRIPTION
Here we work around 2 issues in rustc/llvm:

- A three-way compare using `Ord::cmp` is less efficient than an if-else sequence
- Loops over inclusive ranges `a..=b` are less efficient than loops over exclusive ranges