### PR TITLE
Remove Windows GNU restriction and add CI build for MSVC

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -48,6 +48,10 @@ jobs:
             os: windows-2022
             features: ""
             target: "x86_64-pc-windows-gnu"
+          - rust: stable-x86_64-msvc
+            os: windows-2022
+            features: ""
+            target: "x86_64-pc-windows-msvc"
     steps:
       - name: Checkout sources
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/bzip2.rs
+++ b/bzip2.rs
@@ -31,7 +31,7 @@ extern "C" {
     static mut stdout_handle: *mut FILE;
 }
 
-#[cfg(all(target_os = "windows", target_env = "gnu"))]
+#[cfg(target_os = "windows")]
 extern "C" {
     fn __acrt_iob_func(idx: libc::c_uint) -> *mut FILE;
 }
@@ -43,7 +43,7 @@ macro_rules! STDIN {
     };
 }
 
-#[cfg(all(target_os = "windows", target_env = "gnu"))]
+#[cfg(target_os = "windows")]
 macro_rules! STDIN {
     () => {
         __acrt_iob_func(0)
@@ -57,7 +57,7 @@ macro_rules! STDOUT {
     };
 }
 
-#[cfg(all(target_os = "windows", target_env = "gnu"))]
+#[cfg(target_os = "windows")]
 macro_rules! STDOUT {
     () => {
         __acrt_iob_func(1)

--- a/libbz2-rs-sys/src/high_level.rs
+++ b/libbz2-rs-sys/src/high_level.rs
@@ -33,7 +33,7 @@ extern "C" {
     static mut stdout: *mut FILE;
 }
 
-#[cfg(all(target_os = "windows", target_env = "gnu"))]
+#[cfg(target_os = "windows")]
 extern "C" {
     fn __acrt_iob_func(idx: libc::c_uint) -> *mut FILE;
 }
@@ -45,7 +45,7 @@ macro_rules! STDIN {
     };
 }
 
-#[cfg(all(target_os = "windows", target_env = "gnu"))]
+#[cfg(target_os = "windows")]
 macro_rules! STDIN {
     () => {
         __acrt_iob_func(0)
@@ -59,7 +59,7 @@ macro_rules! STDOUT {
     };
 }
 
-#[cfg(all(target_os = "windows", target_env = "gnu"))]
+#[cfg(target_os = "windows")]
 macro_rules! STDOUT {
     () => {
         __acrt_iob_func(1)


### PR DESCRIPTION
It seems overly restrictive to not allow the library to compile on Windows MSVC. I have removed the `target_env = gnu` restrictions and added a CI build for the MSVC target.