### PR TITLE
Sort perf tweaks

### DIFF
--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -444,7 +444,7 @@ fn mainSimpleSort(
     ptr: &mut [u32],
     block: &[u8],
     quadrant: &[u16],
-    nblock: i32,
+    nblock: usize,
     lo: i32,
     hi: i32,
     d: u32,
@@ -507,7 +507,7 @@ fn mainQSort3(
     ptr: &mut [u32],
     block: &[u8],
     quadrant: &[u16],
-    nblock: i32,
+    nblock: usize,
     loSt: i32,
     hiSt: i32,
     dSt: u32,
@@ -630,12 +630,12 @@ fn mainSort(
     block: &mut [u8],
     quadrant: &mut [u16],
     ftab: &mut [u32; FTAB_LEN],
-    nblock: i32,
+    nblock: usize,
     verb: i32,
     budget: &mut i32,
 ) {
     let mut j: i32;
-    let mut k: i32;
+    let mut k: usize;
     let mut ss: i32;
     let mut sb: i32;
     let mut bigDone: [bool; 256] = [false; 256];
@@ -652,13 +652,13 @@ fn mainSort(
     ftab.fill(0);
 
     j = (block[0] as i32) << 8;
-    for &block in block[..nblock as usize].iter().rev() {
+    for &block in block[..nblock].iter().rev() {
         j = (j >> 8) | (i32::from(block) << 8);
         ftab[j as usize] += 1;
     }
 
     for i in 0..BZ_N_OVERSHOOT {
-        block[nblock as usize + i] = block[i];
+        block[nblock + i] = block[i];
     }
 
     if verb >= 4 as c_int {
@@ -672,7 +672,7 @@ fn mainSort(
 
     s = ((block[0 as c_int as usize] as c_int) << 8 as c_int) as u16;
 
-    for (i, &block) in block[..nblock as usize].iter().enumerate().rev() {
+    for (i, &block) in block[..nblock].iter().enumerate().rev() {
         s = (s >> 8) | (u16::from(block) << 8);
         j = ftab[usize::from(s)] as i32 - 1;
         ftab[usize::from(s)] = j as u32;
@@ -788,9 +788,9 @@ fn mainSort(
             while j < copyStart[ss as usize] {
                 let v = match ptr[j as usize] {
                     0 => nblock,
-                    n => n as i32,
+                    n => n as usize,
                 };
-                k = v.wrapping_sub(1) as i32;
+                k = v.wrapping_sub(1);
                 c1 = block[k as usize];
                 if !bigDone[c1 as usize] {
                     let fresh11 = copyStart[c1 as usize];
@@ -804,10 +804,10 @@ fn mainSort(
             while j > copyEnd[ss as usize] {
                 let v = match ptr[j as usize] {
                     0 => nblock,
-                    n => n as i32,
+                    n => n as usize,
                 };
-                k = v.wrapping_sub(1) as i32;
-                c1 = block[k as usize];
+                k = v.wrapping_sub(1);
+                c1 = block[k];
                 if !bigDone[c1 as usize] {
                     let fresh12 = copyEnd[c1 as usize];
                     copyEnd[c1 as usize] -= 1;
@@ -824,7 +824,7 @@ fn mainSort(
                    Necessity for this case is demonstrated by compressing
                    a sequence of approximately 48.5 million of character
                    251; 1.0.0/1.0.1 will then die here. */
-                (copyStart[ss as usize] == 0 && copyEnd[ss as usize] == nblock-1),
+                (copyStart[ss as usize] == 0 && copyEnd[ss as usize] == nblock as i32 - 1),
             1007
         );
 
@@ -885,7 +885,7 @@ fn mainSort(
                 let qVal: u16 = (j >> shifts) as u16;
                 quadrant[a2update] = qVal;
                 if (a2update as usize) < BZ_N_OVERSHOOT {
-                    quadrant[a2update + nblock as usize] = qVal;
+                    quadrant[a2update + nblock] = qVal;
                 }
             }
 
@@ -897,7 +897,7 @@ fn mainSort(
             "        {} pointers, {} sorted, {} scanned",
             nblock,
             numQSorted,
-            nblock - numQSorted,
+            nblock as i32 - numQSorted,
         );
     }
 }
@@ -956,15 +956,7 @@ fn BZ2_blockSortHelp(
         let budgetInit = nblock as i32 * ((wfact - 1) / 3);
         let mut budget = budgetInit;
 
-        mainSort(
-            ptr,
-            block,
-            quadrant,
-            ftab,
-            nblock as i32,
-            verbosity,
-            &mut budget,
-        );
+        mainSort(ptr, block, quadrant, ftab, nblock, verbosity, &mut budget);
 
         if verbosity >= 3 {
             debug_logln!(

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -225,9 +225,6 @@ fn fallbackSort(
 
     let mut ftab: [i32; 257] = [0; 257];
     let mut ftabCopy: [i32; 256] = [0; 256];
-    let mut H: i32;
-    let mut k: i32;
-    let mut l: i32;
 
     /*--
        Initial 1-char radix sort to generate
@@ -252,7 +249,7 @@ fn fallbackSort(
 
         for (i, e) in eclass8.iter().enumerate() {
             let j = usize::from(*e);
-            k = ftab[j] - 1;
+            let k = ftab[j] - 1;
             ftab[j] = k;
             fmap[k as usize] = i as u32;
         }
@@ -278,7 +275,9 @@ fn fallbackSort(
 
     /*-- the log(N) loop --*/
     let nblock = nblock as i32;
-    H = 1;
+    let mut H = 1;
+    let mut k: i32;
+    let mut l: i32;
     loop {
         if verb >= 4 {
             debug_log!("        depth {:>6} has ", H);

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -190,7 +190,7 @@ fn fallbackSort(
     fmap: &mut [u32],
     arr2: &mut Arr2,
     bhtab: &mut [u32; FTAB_LEN],
-    nblock: i32,
+    nblock: usize,
     verb: i32,
 ) {
     macro_rules! SET_BH {
@@ -277,6 +277,7 @@ fn fallbackSort(
     }
 
     /*-- the log(N) loop --*/
+    let nblock = nblock as i32;
     H = 1;
     loop {
         if verb >= 4 {
@@ -940,7 +941,7 @@ fn BZ2_blockSortHelp(
     verbosity: i32,
 ) {
     if nblock < 10000 {
-        fallbackSort(ptr, arr2, ftab, nblock as i32, verbosity);
+        fallbackSort(ptr, arr2, ftab, nblock, verbosity);
     } else {
         let (block, quadrant) = arr2.block_and_quadrant(nblock);
 
@@ -971,7 +972,7 @@ fn BZ2_blockSortHelp(
                 debug_logln!("    too repetitive; using fallback sorting algorithm");
             }
 
-            fallbackSort(ptr, arr2, ftab, nblock as i32, verbosity);
+            fallbackSort(ptr, arr2, ftab, nblock, verbosity);
         }
     }
 }

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -32,7 +32,7 @@ fn fallbackSimpleSort(fmap: &mut [u32], eclass: &[u32], lo: i32, hi: i32) {
         }
     }
 
-    for i in (lo..=hi - 1).rev() {
+    for i in (lo..hi).rev() {
         tmp = fmap[i as usize] as i32;
         ec_tmp = eclass[tmp as usize];
         j = i + 1;

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -786,10 +786,11 @@ fn mainSort(
 
             j = (ftab[(ss as usize) << 8] & CLEARMASK) as i32;
             while j < copyStart[ss as usize] {
-                k = (ptr[j as usize]).wrapping_sub(1) as i32;
-                if k < 0 as c_int {
-                    k += nblock;
-                }
+                let v = match ptr[j as usize] {
+                    0 => nblock,
+                    n => n as i32,
+                };
+                k = v.wrapping_sub(1) as i32;
                 c1 = block[k as usize];
                 if !bigDone[c1 as usize] {
                     let fresh11 = copyStart[c1 as usize];
@@ -801,10 +802,11 @@ fn mainSort(
 
             j = (ftab[(ss as usize + 1) << 8] & CLEARMASK) as i32 - 1;
             while j > copyEnd[ss as usize] {
-                k = (ptr[j as usize]).wrapping_sub(1) as i32;
-                if k < 0 as c_int {
-                    k += nblock;
-                }
+                let v = match ptr[j as usize] {
+                    0 => nblock,
+                    n => n as i32,
+                };
+                k = v.wrapping_sub(1) as i32;
                 c1 = block[k as usize];
                 if !bigDone[c1 as usize] {
                     let fresh12 = copyEnd[c1 as usize];

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -1,7 +1,6 @@
 #![forbid(unsafe_code)]
 
 use core::cmp::Ordering;
-use core::ffi::{c_int, c_uint};
 
 use crate::{
     assert_h,
@@ -288,7 +287,7 @@ fn fallbackSort(
             if ISSET_BH!(i) {
                 j = i;
             }
-            k = x.wrapping_sub(H as c_uint) as i32;
+            k = x.wrapping_sub(H as u32) as i32;
             if k < 0 {
                 k += nblock;
             }
@@ -644,7 +643,7 @@ fn mainSort(
     let mut c1: u8;
     let mut numQSorted: i32;
     let mut s: u16;
-    if verb >= 4 as c_int {
+    if verb >= 4 {
         debug_logln!("        main sort initialise ...");
     }
 
@@ -661,7 +660,7 @@ fn mainSort(
         block[nblock + i] = block[i];
     }
 
-    if verb >= 4 as c_int {
+    if verb >= 4 {
         debug_logln!("        bucket sorting ...");
     }
 
@@ -670,7 +669,7 @@ fn mainSort(
         ftab[i] += ftab[i - 1];
     }
 
-    s = ((block[0 as c_int as usize] as c_int) << 8 as c_int) as u16;
+    s = u16::from(block[0]) << 8;
 
     for (i, &block) in block[..nblock].iter().enumerate().rev() {
         s = (s >> 8) | (u16::from(block) << 8);
@@ -683,10 +682,10 @@ fn mainSort(
     let mut runningOrder: [i32; 256] = core::array::from_fn(|i| i as i32);
 
     let mut vv: i32;
-    let mut h: i32 = 1 as c_int;
+    let mut h: i32 = 1;
     loop {
-        h = 3 as c_int * h + 1 as c_int;
-        if h > 256 as c_int {
+        h = 3 * h + 1;
+        if h > 256 {
             break;
         }
     }
@@ -698,20 +697,20 @@ fn mainSort(
     }
 
     loop {
-        h /= 3 as c_int;
+        h /= 3;
         for i in h..256 {
             vv = runningOrder[i as usize];
             j = i;
             while BIGFREQ!(runningOrder[(j - h) as usize] as usize) > BIGFREQ!(vv as usize) {
                 runningOrder[j as usize] = runningOrder[(j - h) as usize];
                 j -= h;
-                if j <= h - 1 as c_int {
+                if j < h {
                     break;
                 }
             }
             runningOrder[j as usize] = vv;
         }
-        if h == 1 as c_int {
+        if h == 1 {
             break;
         }
     }
@@ -720,7 +719,7 @@ fn mainSort(
        The main sorting loop.
     --*/
 
-    numQSorted = 0 as c_int;
+    numQSorted = 0;
 
     for i in 0..255 + 1 {
         /*--
@@ -744,24 +743,24 @@ fn mainSort(
         --*/
         for j in 0..255 + 1 {
             if j != ss {
-                sb = (ss << 8 as c_int) + j;
+                sb = (ss << 8) + j;
                 if ftab[sb as usize] & SETMASK == 0 {
                     let lo: i32 = (ftab[sb as usize] & CLEARMASK) as i32;
                     let hi: i32 = ((ftab[sb as usize + 1] & CLEARMASK).wrapping_sub(1)) as i32;
 
                     if hi > lo {
-                        if verb >= 4 as c_int {
+                        if verb >= 4 {
                             debug_logln!(
                                 "        qsort [{:#x}, {:#x}]   done {}   this {}",
                                 ss,
                                 j,
                                 numQSorted,
-                                hi - lo + 1 as c_int,
+                                hi - lo + 1,
                             );
                         }
                         mainQSort3(ptr, block, quadrant, nblock, lo, hi, 2, budget);
-                        numQSorted += hi - lo + 1 as c_int;
-                        if *budget < 0 as c_int {
+                        numQSorted += hi - lo + 1;
+                        if *budget < 0 {
                             return;
                         }
                     }
@@ -921,7 +920,7 @@ pub(crate) fn block_sort(s: &mut EState) {
 
     BZ2_blockSortHelp(ptr, &mut s.arr2, ftab, nblock, s.workFactor, s.verbosity);
 
-    s.origPtr = -1 as c_int;
+    s.origPtr = -1;
     for i in 0..s.nblock {
         if ptr[i as usize] == 0 {
             s.origPtr = i;
@@ -968,7 +967,7 @@ fn BZ2_blockSortHelp(
         }
 
         if budget < 0 {
-            if verbosity >= 2 as c_int {
+            if verbosity >= 2 {
                 debug_logln!("    too repetitive; using fallback sorting algorithm");
             }
 

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -235,7 +235,7 @@ fn fallbackSort(
     }
 
     {
-        let eclass8 = arr2.block(nblock as usize);
+        let eclass8 = arr2.block(nblock);
 
         for e in eclass8.iter() {
             ftab[usize::from(*e)] += 1;
@@ -255,7 +255,7 @@ fn fallbackSort(
         }
     }
 
-    bhtab[0..2 + nblock as usize / 32].fill(0);
+    bhtab[0..2 + nblock / 32].fill(0);
 
     for i in 0..256 {
         SET_BH!(ftab[i]);

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -879,11 +879,11 @@ fn mainSort(
 
             let ptr = &ptr[bbStart as usize..][..bbSize as usize];
             for j in (0..bbSize).rev() {
-                let a2update: i32 = ptr[j as usize] as i32;
+                let a2update = ptr[j as usize] as usize;
                 let qVal: u16 = (j >> shifts) as u16;
-                quadrant[a2update as usize] = qVal;
+                quadrant[a2update] = qVal;
                 if (a2update as usize) < BZ_N_OVERSHOOT {
-                    quadrant[(a2update + nblock) as usize] = qVal;
+                    quadrant[a2update + nblock as usize] = qVal;
                 }
             }
 

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -874,8 +874,8 @@ fn mainSort(
         bigDone[ss as usize] = true;
 
         if i < 255 {
-            let bbStart: i32 = (ftab[(ss as usize) << 8] & CLEARMASK) as i32;
-            let bbSize: i32 = (ftab[(ss as usize + 1) << 8] & CLEARMASK) as i32 - bbStart;
+            let bbStart = ftab[(ss as usize) << 8] & CLEARMASK;
+            let bbSize = (ftab[(ss as usize + 1) << 8] & CLEARMASK) as i32 - bbStart as i32;
 
             let shifts = (bbSize >> 16).count_ones();
 
@@ -892,7 +892,7 @@ fn mainSort(
             assert_h!(((bbSize - 1) >> shifts) <= 65535, 1002);
         }
     }
-    if verb >= 4 as c_int {
+    if verb >= 4 {
         debug_logln!(
             "        {} pointers, {} sorted, {} scanned",
             nblock,

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -874,11 +874,8 @@ fn mainSort(
         if i < 255 {
             let bbStart: i32 = (ftab[(ss as usize) << 8] & CLEARMASK) as i32;
             let bbSize: i32 = (ftab[(ss as usize + 1) << 8] & CLEARMASK) as i32 - bbStart;
-            let mut shifts: i32 = 0 as c_int;
 
-            while bbSize >> shifts > 65534 as c_int {
-                shifts += 1;
-            }
+            let shifts = (bbSize >> 16).count_ones();
 
             let ptr = &ptr[bbStart as usize..][..bbSize as usize];
             for j in (0..bbSize).rev() {

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -722,7 +722,7 @@ fn mainSort(
 
     numQSorted = 0 as c_int;
 
-    for i in 0..=255 {
+    for i in 0..255 + 1 {
         /*--
            Process big buckets, starting with the least full.
            Basically this is a 3-step process in which we call
@@ -742,7 +742,7 @@ fn mainSort(
            completed many of the small buckets [ss, j], so
            we don't have to sort them at all.
         --*/
-        for j in 0..=255 {
+        for j in 0..255 + 1 {
             if j != ss {
                 sb = (ss << 8 as c_int) + j;
                 if ftab[sb as usize] & SETMASK == 0 {

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -791,7 +791,7 @@ fn mainSort(
                     n => n as usize,
                 };
                 k = v.wrapping_sub(1);
-                c1 = block[k as usize];
+                c1 = block[k];
                 if !bigDone[c1 as usize] {
                     let fresh11 = copyStart[c1 as usize];
                     copyStart[c1 as usize] += 1;
@@ -884,7 +884,7 @@ fn mainSort(
                 let a2update = ptr[j as usize] as usize;
                 let qVal: u16 = (j >> shifts) as u16;
                 quadrant[a2update] = qVal;
-                if (a2update as usize) < BZ_N_OVERSHOOT {
+                if a2update < BZ_N_OVERSHOOT {
                     quadrant[a2update + nblock] = qVal;
                 }
             }

--- a/libbz2-rs-sys/src/blocksort.rs
+++ b/libbz2-rs-sys/src/blocksort.rs
@@ -871,7 +871,7 @@ fn mainSort(
         --*/
         bigDone[ss as usize] = true;
 
-        if i < 255 as c_int {
+        if i < 255 {
             let bbStart: i32 = (ftab[(ss as usize) << 8] & CLEARMASK) as i32;
             let bbSize: i32 = (ftab[(ss as usize + 1) << 8] & CLEARMASK) as i32 - bbStart;
             let mut shifts: i32 = 0 as c_int;
@@ -880,15 +880,14 @@ fn mainSort(
                 shifts += 1;
             }
 
-            j = bbSize - 1 as c_int;
-            while j >= 0 as c_int {
-                let a2update: i32 = ptr[(bbStart + j) as usize] as i32;
+            let ptr = &ptr[bbStart as usize..][..bbSize as usize];
+            for j in (0..bbSize).rev() {
+                let a2update: i32 = ptr[j as usize] as i32;
                 let qVal: u16 = (j >> shifts) as u16;
                 quadrant[a2update as usize] = qVal;
                 if (a2update as usize) < BZ_N_OVERSHOOT {
                     quadrant[(a2update + nblock) as usize] = qVal;
                 }
-                j -= 1;
             }
 
             assert_h!(((bbSize - 1) >> shifts) <= 65535, 1002);


### PR DESCRIPTION
versus `main`

```
Benchmark 2 (1667 runs): target/release/bzip2 -kf blocksort.c
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          2.96ms ±  110us    2.65ms … 3.76ms        202 (12%)          +  0.1% ±  0.4%
  peak_rss           2.64MB ± 62.5KB    2.49MB … 2.75MB        404 (24%)          +  0.1% ±  0.2%
  cpu_cycles         7.42M  ±  195K     7.04M  … 9.70M          98 ( 6%)          +  0.6% ±  0.2%
  instructions       14.4M  ±  321      14.4M  … 14.4M           9 ( 1%)        ⚡-  4.0% ±  0.0%
  cache_references    465K  ± 26.9K      286K  …  561K          33 ( 2%)          +  0.8% ±  0.4%
```

that icount reduction is very robust, but on my machine does not actually reduce cycles/wall_time. I think these changes are valuable in and of themselves though, e.g. using unsigned types is just clearer.