### PR TITLE
change `BZ2_bzerror` to not panic on a NULL pointer

### DIFF
--- a/libbz2-rs-sys/src/high_level.rs
+++ b/libbz2-rs-sys/src/high_level.rs
@@ -1261,10 +1261,18 @@ const BZERRORSTRINGS: [&str; 16] = [
 /// [`pointer::as_mut`]: https://doc.rust-lang.org/core/primitive.pointer.html#method.as_mut
 #[export_name = prefix!(BZ2_bzerror)]
 pub unsafe extern "C" fn BZ2_bzerror(b: *const BZFILE, errnum: *mut c_int) -> *const c_char {
-    BZ2_bzerrorHelp(
-        b.as_ref().expect("Passed null pointer to BZ2_bzerror"),
-        errnum.as_mut(),
-    )
+    // The C implementation dereferences `b` unconditionally, we just return "???".
+    let errnum = errnum.as_mut();
+    match b.as_ref() {
+        Some(b) => BZ2_bzerrorHelp(b, errnum),
+        None => {
+            if let Some(errnum) = errnum {
+                *errnum = crate::BZ_PARAM_ERROR;
+            }
+            let msg = "BZ2_bzerror was passed a NULL pointer\0";
+            msg.as_ptr().cast::<c_char>()
+        }
+    }
 }
 
 fn BZ2_bzerrorHelp(b: &BZFILE, errnum: Option<&mut c_int>) -> *const c_char {
@@ -1282,6 +1290,33 @@ fn BZ2_bzerrorHelp(b: &BZFILE, errnum: Option<&mut c_int>) -> *const c_char {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn bz_error_file_is_null_ptr() {
+        let mut errnum = 0;
+        let ptr = unsafe { BZ2_bzerror(core::ptr::null(), &mut errnum) };
+        let cstr = unsafe { CStr::from_ptr(ptr) };
+
+        assert_eq!(
+            cstr.to_str().unwrap(),
+            "BZ2_bzerror was passed a NULL pointer"
+        )
+    }
+
+    #[test]
+    fn bz_error_errnum_is_null_ptr() {
+        let bz_file = BZFILE {
+            handle: core::ptr::null_mut(),
+            buf: [0; 5000],
+            bufN: 0,
+            strm: bz_stream::zeroed(),
+            lastErr: ReturnCode::BZ_OK,
+            operation: Operation::Reading,
+            initialisedOk: false,
+        };
+
+        unsafe { BZ2_bzerror(&bz_file, core::ptr::null_mut()) };
+    }
 
     #[test]
     fn error_messages() {
@@ -1316,7 +1351,7 @@ mod tests {
             bz_file.lastErr = return_code;
 
             let mut errnum = 0;
-            let ptr = unsafe { BZ2_bzerror(&bz_file as *const BZFILE, &mut errnum) };
+            let ptr = unsafe { BZ2_bzerror(&bz_file, &mut errnum) };
             assert!(!ptr.is_null());
             let cstr = unsafe { CStr::from_ptr(ptr) };
 


### PR DESCRIPTION
the C implementation would dereference the NULL pointer, hence trigger UB, so we're free to do whatever.

We could return `"???\0" instead? This is probably nicer though if it does come up.