### PR TITLE
Install C header via `cargo cinstall`

### DIFF
--- a/libbz2-rs-sys-cdylib/Cargo.toml
+++ b/libbz2-rs-sys-cdylib/Cargo.toml
@@ -32,7 +32,10 @@ version = "1.0.9" # the bzip2 api version we match
 name = "bz2_rs"
 
 [package.metadata.capi.header]
-enabled = false
+generation = false
+
+[package.metadata.capi.install.include]
+asset = [{from="../bzlib.h"}]
 
 [package.metadata.capi.pkg_config]
 name = "libbz2_rs"


### PR DESCRIPTION
Note that `libbz2-rs-sys/include/bzlib.h` is currently a symlink to the `bzlib.h` file. On Windows, however, it becomes a regular file and `cargo-c` fails to resolve the path contained within it. Therefore, we cannot use this path in `Cargo.toml`.

Before:
```text
.install/
└── usr
    └── local
        └── lib
            ├── libbz2_rs.a
            ├── libbz2_rs.so -> libbz2_rs.so.1.0.9
            ├── libbz2_rs.so.1 -> libbz2_rs.so.1.0.9
            ├── libbz2_rs.so.1.0.9
            └── pkgconfig
                └── libbz2_rs.pc
```

After:
```text
.install/
└── usr
    └── local
        ├── include
        │   └── bz2_rs
        │       └── bzlib.h
        └── lib
            ├── libbz2_rs.a
            ├── libbz2_rs.so -> libbz2_rs.so.1.0.9
            ├── libbz2_rs.so.1 -> libbz2_rs.so.1.0.9
            ├── libbz2_rs.so.1.0.9
            └── pkgconfig
                └── libbz2_rs.pc
```